### PR TITLE
fix: add CLI project argument support and implement interactive features

### DIFF
--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -64,6 +64,7 @@ export function createCli(): Command {
     .name('workon')
     .description('Work on something great!')
     .version(packageJson.version)
+    .argument('[project]', 'Project name to open (supports project:command syntax)')
     .option('-d, --debug', 'Enable debug logging')
     .option('--completion', 'Setup shell tab completion')
     .option('--shell', 'Output shell commands for evaluation')
@@ -74,33 +75,47 @@ export function createCli(): Command {
         log.setLogLevel('debug');
       }
     })
-    .action(async (options: GlobalOptions & { completion?: boolean; init?: boolean }) => {
-      if (options.debug) {
-        log.setLogLevel('debug');
+    .action(
+      async (
+        project: string | undefined,
+        options: GlobalOptions & { completion?: boolean; init?: boolean }
+      ) => {
+        if (options.debug) {
+          log.setLogLevel('debug');
+        }
+
+        if (options.completion) {
+          log.debug('Setting up command-line completion');
+          completion.setupShellInitFile();
+          return;
+        }
+
+        if (options.init) {
+          log.debug('Generating shell integration function');
+          outputShellInit(program);
+          return;
+        }
+
+        // If a project name was provided, delegate to the open command
+        if (project) {
+          const args = ['open', project];
+          if (options.shell) args.push('--shell');
+          if (options.debug) args.push('--debug');
+          await program.parseAsync(['node', 'workon', ...args]);
+          return;
+        }
+
+        // Default action: run interactive mode
+        const environment = await EnvironmentRecognizer.recognize(File.cwd());
+        program.setOptionValue('_environment', environment);
+        program.setOptionValue('_config', config);
+        program.setOptionValue('_log', log);
+
+        // Import and run interactive command
+        const { runInteractive } = await import('./interactive.js');
+        await runInteractive({ config, log, environment });
       }
-
-      if (options.completion) {
-        log.debug('Setting up command-line completion');
-        completion.setupShellInitFile();
-        return;
-      }
-
-      if (options.init) {
-        log.debug('Generating shell integration function');
-        outputShellInit(program);
-        return;
-      }
-
-      // Default action: run interactive mode or show help
-      const environment = await EnvironmentRecognizer.recognize(File.cwd());
-      program.setOptionValue('_environment', environment);
-      program.setOptionValue('_config', config);
-      program.setOptionValue('_log', log);
-
-      // Import and run interactive command
-      const { runInteractive } = await import('./interactive.js');
-      await runInteractive({ config, log, environment });
-    });
+    );
 
   // Store shared state for subcommands
   program.setOptionValue('_config', config);

--- a/src/commands/interactive.ts
+++ b/src/commands/interactive.ts
@@ -1,9 +1,11 @@
-import { select, input, checkbox } from '@inquirer/prompts';
+import { select, input, checkbox, confirm } from '@inquirer/prompts';
 import File from 'phylo';
 import deepAssign from 'deep-assign';
 import type { Config } from '../lib/config.js';
 import type { Logger, ProjectConfig, EventsConfig, IdeType } from '../types/index.js';
 import type { Environment, ProjectEnvironment as ProjectEnv } from '../lib/environment.js';
+import { ProjectEnvironment } from '../lib/environment.js';
+import { EventRegistry } from '../events/registry.js';
 
 interface InteractiveContext {
   config: Config;
@@ -76,24 +78,20 @@ async function startInteractive(
       return;
 
     case 'switch-project':
-      log.info('Switch to an existing project');
-      // TODO: Implement project switching
-      break;
+      await switchProject(ctx);
+      return;
 
     case 'switch-branch':
-      log.info('Switch to an existing branch');
-      // TODO: Implement branch switching
-      break;
+      await switchBranch(defaultName, ctx);
+      return;
 
     case 'manage-projects':
-      log.info('Manage existing projects');
-      // Redirect to manage command
-      break;
+      await manageProjects(ctx);
+      return;
 
     case 'manage-branches':
-      log.info('Manage existing branches');
-      // TODO: Implement branch management
-      break;
+      await manageBranches(defaultName, ctx);
+      return;
   }
 }
 
@@ -259,4 +257,551 @@ async function initBranch(defaultName: string, ctx: InteractiveContext): Promise
 
   log.info('Your branch configuration has been initialized.');
   log.info(`Use 'workon ${branchName}' to start working!`);
+}
+
+async function switchProject(ctx: InteractiveContext): Promise<void> {
+  const { config, log } = ctx;
+  const projects = config.getProjects();
+
+  // Filter to only base projects (not branch configs)
+  const baseProjects = Object.keys(projects).filter((name) => !name.includes('#'));
+
+  if (baseProjects.length === 0) {
+    log.info('No projects configured yet. Use "Start a new project" to create one.');
+    return;
+  }
+
+  const projectName = await select({
+    message: 'Select a project to open:',
+    choices: baseProjects.map((name) => ({
+      name: `${name} (${projects[name].path})`,
+      value: name,
+    })),
+  });
+
+  await openProject(projectName, ctx);
+}
+
+async function switchBranch(projectName: string, ctx: InteractiveContext): Promise<void> {
+  const { config, log } = ctx;
+  const projects = config.getProjects();
+
+  // Find all branch configs for this project
+  const branchPrefix = `${projectName}#`;
+  const branches = Object.keys(projects).filter((name) => name.startsWith(branchPrefix));
+
+  if (branches.length === 0) {
+    log.info(`No branch configurations found for '${projectName}'.`);
+    log.info('Use "Start a branch" to create one.');
+    return;
+  }
+
+  const branchConfig = await select({
+    message: 'Select a branch configuration:',
+    choices: branches.map((name) => ({
+      name: name.substring(branchPrefix.length),
+      value: name,
+    })),
+  });
+
+  await openProject(branchConfig, ctx);
+}
+
+async function manageProjects(ctx: InteractiveContext): Promise<void> {
+  const { config } = ctx;
+
+  // Initialize event registry for manage operations
+  await EventRegistry.initialize();
+
+  const projects = config.getProjects();
+  const hasProjects = Object.keys(projects).length > 0;
+
+  const choices = [
+    { name: 'Create new project', value: 'create' },
+    ...(hasProjects
+      ? [
+          { name: 'Edit project', value: 'edit' },
+          { name: 'Delete project', value: 'delete' },
+          { name: 'List projects', value: 'list' },
+        ]
+      : []),
+    { name: 'Back', value: 'back' },
+  ];
+
+  const action = await select({
+    message: 'Manage projects:',
+    choices,
+  });
+
+  switch (action) {
+    case 'create':
+      await createProjectManage(ctx);
+      break;
+    case 'edit':
+      await editProjectManage(ctx);
+      break;
+    case 'delete':
+      await deleteProjectManage(ctx);
+      break;
+    case 'list':
+      listProjectsManage(ctx);
+      break;
+    case 'back':
+      return;
+  }
+
+  // Return to manage menu
+  await manageProjects(ctx);
+}
+
+async function manageBranches(projectName: string, ctx: InteractiveContext): Promise<void> {
+  const { config } = ctx;
+  const projects = config.getProjects();
+
+  // Find all branch configs for this project
+  const branchPrefix = `${projectName}#`;
+  const branches = Object.keys(projects).filter((name) => name.startsWith(branchPrefix));
+
+  const choices = [
+    { name: 'Create new branch config', value: 'create' },
+    ...(branches.length > 0
+      ? [
+          { name: 'Edit branch config', value: 'edit' },
+          { name: 'Delete branch config', value: 'delete' },
+          { name: 'List branch configs', value: 'list' },
+        ]
+      : []),
+    { name: 'Back', value: 'back' },
+  ];
+
+  const action = await select({
+    message: `Manage branches for '${projectName}':`,
+    choices,
+  });
+
+  switch (action) {
+    case 'create':
+      await initBranch(projectName, ctx);
+      break;
+    case 'edit':
+      await editBranchManage(projectName, ctx);
+      break;
+    case 'delete':
+      await deleteBranchManage(projectName, ctx);
+      break;
+    case 'list':
+      listBranchesManage(projectName, ctx);
+      break;
+    case 'back':
+      return;
+  }
+
+  // Return to manage branches menu
+  await manageBranches(projectName, ctx);
+}
+
+async function openProject(projectName: string, ctx: InteractiveContext): Promise<void> {
+  const { config, log } = ctx;
+  const projects = config.getProjects();
+
+  if (!(projectName in projects)) {
+    log.error(`Project '${projectName}' not found.`);
+    return;
+  }
+
+  // Initialize event registry if needed
+  await EventRegistry.initialize();
+
+  const projectConfig = projects[projectName];
+  const projectCfg = { ...projectConfig, name: projectName };
+  const projectEnv = ProjectEnvironment.load(projectCfg, config.getDefaults());
+
+  log.info(`Opening project '${projectName}'...`);
+
+  // Execute events for the project
+  const events = Object.keys(projectConfig.events).filter(
+    (e) => projectConfig.events[e as keyof EventsConfig]
+  );
+
+  for (const event of events) {
+    const eventHandler = EventRegistry.getEventByName(event);
+    if (eventHandler && (eventHandler as any).processing) {
+      await (eventHandler as any).processing.processEvent({
+        project: projectEnv.project,
+        isShellMode: false,
+        shellCommands: [],
+      });
+    }
+  }
+}
+
+// Manage helper functions
+async function createProjectManage(ctx: InteractiveContext): Promise<void> {
+  const { config, log } = ctx;
+  const defaults = config.getDefaults();
+  const projects = config.getProjects();
+
+  const name = await input({
+    message: 'Project name:',
+    validate: (value) => {
+      if (!value.trim()) return 'Name is required';
+      if (!/^[\w-]+$/.test(value))
+        return 'Name can only contain letters, numbers, underscores, and hyphens';
+      if (value in projects) return 'Project already exists';
+      return true;
+    },
+  });
+
+  const defaultPath = defaults?.base ? File.from(defaults.base).join(name).path : name;
+  const pathInput = await input({
+    message: 'Project path:',
+    default: defaultPath,
+  });
+
+  let relativePath = pathInput;
+  if (defaults?.base) {
+    const baseDir = File.from(defaults.base);
+    const pathFile = File.from(pathInput);
+    try {
+      if (pathFile.isAbsolute()) {
+        relativePath = pathFile.relativize(baseDir.path).path;
+      }
+    } catch {
+      relativePath = pathInput;
+    }
+  }
+
+  const ide = await select({
+    message: 'Select IDE:',
+    choices: IDE_CHOICES,
+  });
+
+  const availableEvents = EventRegistry.getEventsForManageUI();
+  const selectedEvents = await checkbox({
+    message: 'Select events to enable:',
+    choices: availableEvents.map((e) => ({
+      name: `${e.name} - ${e.description}`,
+      value: e.value,
+      checked: e.value === 'cwd' || e.value === 'ide',
+    })),
+  });
+
+  const events: EventsConfig = {};
+  for (const eventName of selectedEvents) {
+    const eventHandler = EventRegistry.getEventByName(eventName);
+    if (eventHandler) {
+      const eventConfig = await (eventHandler as any).configuration.configureInteractive();
+      events[eventName as keyof EventsConfig] = eventConfig;
+    }
+  }
+
+  const projectConfig: ProjectConfig = {
+    path: relativePath,
+    ide,
+    events,
+  };
+
+  const confirmed = await confirm({
+    message: 'Save this project?',
+    default: true,
+  });
+
+  if (confirmed) {
+    config.setProject(name, projectConfig);
+    log.info(`Project '${name}' created successfully!`);
+  }
+}
+
+async function editProjectManage(ctx: InteractiveContext): Promise<void> {
+  const { config, log } = ctx;
+  const projects = config.getProjects();
+  const defaults = config.getDefaults();
+
+  // Filter to base projects only
+  const baseProjects = Object.keys(projects).filter((name) => !name.includes('#'));
+
+  if (baseProjects.length === 0) {
+    log.info('No projects to edit.');
+    return;
+  }
+
+  const name = await select({
+    message: 'Select project to edit:',
+    choices: baseProjects.map((n) => ({ name: n, value: n })),
+  });
+
+  const project = projects[name];
+
+  const pathInput = await input({
+    message: 'Project path:',
+    default: project.path,
+  });
+
+  let relativePath = pathInput;
+  if (defaults?.base) {
+    const baseDir = File.from(defaults.base);
+    const pathFile = File.from(pathInput);
+    try {
+      if (pathFile.isAbsolute()) {
+        relativePath = pathFile.relativize(baseDir.path).path;
+      }
+    } catch {
+      relativePath = pathInput;
+    }
+  }
+
+  const ide = await select({
+    message: 'Select IDE:',
+    choices: IDE_CHOICES,
+    default: project.ide || 'vscode',
+  });
+
+  const keepEvents = await confirm({
+    message: 'Keep existing event configuration?',
+    default: true,
+  });
+
+  let events = project.events;
+  if (!keepEvents) {
+    const availableEvents = EventRegistry.getEventsForManageUI();
+    const currentEvents = Object.keys(project.events);
+
+    const selectedEvents = await checkbox({
+      message: 'Select events to enable:',
+      choices: availableEvents.map((e) => ({
+        name: `${e.name} - ${e.description}`,
+        value: e.value,
+        checked: currentEvents.includes(e.value),
+      })),
+    });
+
+    events = {};
+    for (const eventName of selectedEvents) {
+      if (project.events[eventName as keyof EventsConfig]) {
+        (events as Record<string, unknown>)[eventName] =
+          project.events[eventName as keyof EventsConfig];
+      } else {
+        const eventHandler = EventRegistry.getEventByName(eventName);
+        if (eventHandler) {
+          const eventConfig = await (eventHandler as any).configuration.configureInteractive();
+          events[eventName as keyof EventsConfig] = eventConfig;
+        }
+      }
+    }
+  }
+
+  const updatedConfig: ProjectConfig = {
+    path: relativePath,
+    ide,
+    events,
+  };
+
+  const confirmed = await confirm({
+    message: 'Save changes?',
+    default: true,
+  });
+
+  if (confirmed) {
+    config.setProject(name, updatedConfig);
+    log.info(`Project '${name}' updated successfully!`);
+  }
+}
+
+async function deleteProjectManage(ctx: InteractiveContext): Promise<void> {
+  const { config, log } = ctx;
+  const projects = config.getProjects();
+
+  // Filter to base projects only
+  const baseProjects = Object.keys(projects).filter((name) => !name.includes('#'));
+
+  if (baseProjects.length === 0) {
+    log.info('No projects to delete.');
+    return;
+  }
+
+  const name = await select({
+    message: 'Select project to delete:',
+    choices: baseProjects.map((n) => ({ name: n, value: n })),
+  });
+
+  // Check for branch configs
+  const branchPrefix = `${name}#`;
+  const branches = Object.keys(projects).filter((n) => n.startsWith(branchPrefix));
+
+  if (branches.length > 0) {
+    log.warn(`This project has ${branches.length} branch configuration(s).`);
+    const deleteAll = await confirm({
+      message: 'Delete all branch configurations as well?',
+      default: false,
+    });
+
+    if (deleteAll) {
+      for (const branch of branches) {
+        config.deleteProject(branch);
+      }
+    }
+  }
+
+  const confirmed = await confirm({
+    message: `Are you sure you want to delete '${name}'?`,
+    default: false,
+  });
+
+  if (confirmed) {
+    config.deleteProject(name);
+    log.info(`Project '${name}' deleted.`);
+  }
+}
+
+function listProjectsManage(ctx: InteractiveContext): void {
+  const { config } = ctx;
+  const projects = config.getProjects();
+  const defaults = config.getDefaults();
+
+  console.log('\nConfigured projects:\n');
+
+  // Filter to base projects only
+  const baseProjects = Object.keys(projects).filter((name) => !name.includes('#'));
+
+  for (const name of baseProjects) {
+    const project = projects[name];
+    const fullPath = defaults?.base
+      ? File.from(defaults.base).join(project.path).path
+      : project.path;
+
+    console.log(`  ${name}`);
+    console.log(`    Path: ${fullPath}`);
+    console.log(`    IDE: ${project.ide || 'not set'}`);
+    console.log(`    Events: ${Object.keys(project.events).join(', ') || 'none'}`);
+
+    // Show branch count
+    const branchPrefix = `${name}#`;
+    const branches = Object.keys(projects).filter((n) => n.startsWith(branchPrefix));
+    if (branches.length > 0) {
+      console.log(`    Branches: ${branches.length}`);
+    }
+    console.log();
+  }
+}
+
+async function editBranchManage(projectName: string, ctx: InteractiveContext): Promise<void> {
+  const { config, log } = ctx;
+  const projects = config.getProjects();
+
+  const branchPrefix = `${projectName}#`;
+  const branches = Object.keys(projects).filter((name) => name.startsWith(branchPrefix));
+
+  if (branches.length === 0) {
+    log.info('No branch configurations to edit.');
+    return;
+  }
+
+  const branchName = await select({
+    message: 'Select branch configuration to edit:',
+    choices: branches.map((n) => ({
+      name: n.substring(branchPrefix.length),
+      value: n,
+    })),
+  });
+
+  const branch = projects[branchName];
+
+  const keepEvents = await confirm({
+    message: 'Keep existing event configuration?',
+    default: true,
+  });
+
+  let events = branch.events;
+  if (!keepEvents) {
+    const availableEvents = EventRegistry.getEventsForManageUI();
+    const currentEvents = Object.keys(branch.events);
+
+    const selectedEvents = await checkbox({
+      message: 'Select events to enable:',
+      choices: availableEvents.map((e) => ({
+        name: `${e.name} - ${e.description}`,
+        value: e.value,
+        checked: currentEvents.includes(e.value),
+      })),
+    });
+
+    events = {};
+    for (const eventName of selectedEvents) {
+      if (branch.events[eventName as keyof EventsConfig]) {
+        (events as Record<string, unknown>)[eventName] =
+          branch.events[eventName as keyof EventsConfig];
+      } else {
+        const eventHandler = EventRegistry.getEventByName(eventName);
+        if (eventHandler) {
+          const eventConfig = await (eventHandler as any).configuration.configureInteractive();
+          events[eventName as keyof EventsConfig] = eventConfig;
+        }
+      }
+    }
+  }
+
+  const updatedConfig: ProjectConfig = {
+    ...branch,
+    events,
+  };
+
+  const confirmed = await confirm({
+    message: 'Save changes?',
+    default: true,
+  });
+
+  if (confirmed) {
+    config.setProject(branchName, updatedConfig);
+    log.info(`Branch configuration '${branchName}' updated successfully!`);
+  }
+}
+
+async function deleteBranchManage(projectName: string, ctx: InteractiveContext): Promise<void> {
+  const { config, log } = ctx;
+  const projects = config.getProjects();
+
+  const branchPrefix = `${projectName}#`;
+  const branches = Object.keys(projects).filter((name) => name.startsWith(branchPrefix));
+
+  if (branches.length === 0) {
+    log.info('No branch configurations to delete.');
+    return;
+  }
+
+  const branchName = await select({
+    message: 'Select branch configuration to delete:',
+    choices: branches.map((n) => ({
+      name: n.substring(branchPrefix.length),
+      value: n,
+    })),
+  });
+
+  const confirmed = await confirm({
+    message: `Are you sure you want to delete '${branchName}'?`,
+    default: false,
+  });
+
+  if (confirmed) {
+    config.deleteProject(branchName);
+    log.info(`Branch configuration '${branchName}' deleted.`);
+  }
+}
+
+function listBranchesManage(projectName: string, ctx: InteractiveContext): void {
+  const { config } = ctx;
+  const projects = config.getProjects();
+
+  const branchPrefix = `${projectName}#`;
+  const branches = Object.keys(projects).filter((name) => name.startsWith(branchPrefix));
+
+  console.log(`\nBranch configurations for '${projectName}':\n`);
+
+  for (const branchName of branches) {
+    const branch = projects[branchName];
+    const shortName = branchName.substring(branchPrefix.length);
+
+    console.log(`  ${shortName}`);
+    console.log(`    Events: ${Object.keys(branch.events).join(', ') || 'none'}`);
+    console.log();
+  }
 }

--- a/tests/commands/cli-index.test.ts
+++ b/tests/commands/cli-index.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createCli } from '../../src/commands/index.js';
+import { Config } from '../../src/lib/config.js';
+
+// Mock inquirer prompts to avoid interactive prompts in tests
+vi.mock('@inquirer/prompts', () => ({
+  select: vi.fn().mockResolvedValue('exit'),
+  input: vi.fn().mockResolvedValue('test'),
+  checkbox: vi.fn().mockResolvedValue([]),
+  confirm: vi.fn().mockResolvedValue(false),
+}));
+
+// Mock TmuxManager
+vi.mock('../../src/lib/tmux.js', () => ({
+  TmuxManager: vi.fn().mockImplementation(() => ({
+    isTmuxAvailable: vi.fn().mockResolvedValue(false),
+    getSessionName: vi.fn((name: string) => `workon-${name}`),
+    buildShellCommands: vi.fn(() => ['# mock tmux commands']),
+  })),
+}));
+
+// Mock child_process
+vi.mock('child_process', () => ({
+  spawn: vi.fn(() => ({ unref: vi.fn() })),
+}));
+
+describe('createCli', () => {
+  let config: Config;
+
+  beforeEach(() => {
+    config = new Config();
+  });
+
+  afterEach(() => {
+    try {
+      config.deleteProject('testproject');
+    } catch {
+      // Ignore cleanup errors
+    }
+  });
+
+  it('should create a CLI program named "workon"', () => {
+    const program = createCli();
+    expect(program.name()).toBe('workon');
+  });
+
+  it('should have a project argument', () => {
+    const program = createCli();
+    expect(program.registeredArguments.length).toBeGreaterThanOrEqual(1);
+    expect(program.registeredArguments[0].name()).toBe('project');
+  });
+
+  it('should have debug option', () => {
+    const program = createCli();
+    const debugOpt = program.options.find((o) => o.long === '--debug');
+    expect(debugOpt).toBeDefined();
+  });
+
+  it('should have shell option', () => {
+    const program = createCli();
+    const shellOpt = program.options.find((o) => o.long === '--shell');
+    expect(shellOpt).toBeDefined();
+  });
+
+  it('should have init option', () => {
+    const program = createCli();
+    const initOpt = program.options.find((o) => o.long === '--init');
+    expect(initOpt).toBeDefined();
+  });
+
+  it('should have completion option', () => {
+    const program = createCli();
+    const completionOpt = program.options.find((o) => o.long === '--completion');
+    expect(completionOpt).toBeDefined();
+  });
+
+  describe('subcommands', () => {
+    it('should have "open" command', () => {
+      const program = createCli();
+      const openCmd = program.commands.find((c) => c.name() === 'open');
+      expect(openCmd).toBeDefined();
+    });
+
+    it('should have "add" command', () => {
+      const program = createCli();
+      const addCmd = program.commands.find((c) => c.name() === 'add');
+      expect(addCmd).toBeDefined();
+    });
+
+    it('should have "config" command', () => {
+      const program = createCli();
+      const configCmd = program.commands.find((c) => c.name() === 'config');
+      expect(configCmd).toBeDefined();
+    });
+
+    it('should have "manage" command', () => {
+      const program = createCli();
+      const manageCmd = program.commands.find((c) => c.name() === 'manage');
+      expect(manageCmd).toBeDefined();
+    });
+  });
+
+  describe('project argument handling', () => {
+    it('should accept project name as argument', () => {
+      const program = createCli();
+      // The argument should be optional and named 'project'
+      const projectArg = program.registeredArguments[0];
+      expect(projectArg.name()).toBe('project');
+      expect(projectArg.required).toBe(false);
+    });
+
+    it('should support project:command syntax in argument description', () => {
+      const program = createCli();
+      const projectArg = program.registeredArguments[0];
+      expect(projectArg.description).toContain('project:command');
+    });
+  });
+});

--- a/tests/commands/interactive.test.ts
+++ b/tests/commands/interactive.test.ts
@@ -3,16 +3,32 @@ import { Config } from '../../src/lib/config.js';
 import { BaseEnvironment, ProjectEnvironment } from '../../src/lib/environment.js';
 
 // Use vi.hoisted to ensure mocks are available when vi.mock is hoisted
-const { mockSelect, mockInput, mockCheckbox } = vi.hoisted(() => ({
+const { mockSelect, mockInput, mockCheckbox, mockConfirm } = vi.hoisted(() => ({
   mockSelect: vi.fn(),
   mockInput: vi.fn(),
   mockCheckbox: vi.fn(),
+  mockConfirm: vi.fn(),
 }));
 
 vi.mock('@inquirer/prompts', () => ({
   select: mockSelect,
   input: mockInput,
   checkbox: mockCheckbox,
+  confirm: mockConfirm,
+}));
+
+// Mock TmuxManager to avoid actual tmux calls
+vi.mock('../../src/lib/tmux.js', () => ({
+  TmuxManager: vi.fn().mockImplementation(() => ({
+    isTmuxAvailable: vi.fn().mockResolvedValue(false),
+    getSessionName: vi.fn((name: string) => `workon-${name}`),
+    buildShellCommands: vi.fn(() => ['# mock tmux commands']),
+  })),
+}));
+
+// Mock child_process to avoid actual spawns
+vi.mock('child_process', () => ({
+  spawn: vi.fn(() => ({ unref: vi.fn() })),
 }));
 
 // Import after mocking
@@ -47,6 +63,7 @@ describe('interactive command', () => {
     mockSelect.mockReset();
     mockInput.mockReset();
     mockCheckbox.mockReset();
+    mockConfirm.mockReset();
   });
 
   afterEach(() => {
@@ -203,5 +220,502 @@ describe('IDE_CHOICES', () => {
     );
 
     localConfig.deleteProject('idetest');
+  });
+});
+
+describe('switch-project flow', () => {
+  let config: Config;
+  let mockLog: {
+    debug: ReturnType<typeof vi.fn>;
+    info: ReturnType<typeof vi.fn>;
+    log: ReturnType<typeof vi.fn>;
+    warn: ReturnType<typeof vi.fn>;
+    error: ReturnType<typeof vi.fn>;
+    setLogLevel: ReturnType<typeof vi.fn>;
+  };
+  let consoleSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    config = new Config();
+    mockLog = {
+      debug: vi.fn(),
+      info: vi.fn(),
+      log: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      setLogLevel: vi.fn(),
+    };
+    consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    mockSelect.mockReset();
+    mockInput.mockReset();
+    mockCheckbox.mockReset();
+    mockConfirm.mockReset();
+  });
+
+  afterEach(() => {
+    consoleSpy.mockRestore();
+    try {
+      config.deleteProject('proj1');
+      config.deleteProject('proj2');
+    } catch {
+      // Ignore cleanup errors
+    }
+  });
+
+  it('should show message when no projects exist', async () => {
+    mockSelect.mockResolvedValueOnce('switch-project');
+
+    await runInteractive({
+      config,
+      log: mockLog,
+      environment: new BaseEnvironment(),
+    });
+
+    expect(mockLog.info).toHaveBeenCalledWith(
+      expect.stringContaining('No projects configured')
+    );
+  });
+
+  it('should list existing projects for selection', async () => {
+    // Create test projects
+    config.setProject('proj1', { path: '/tmp/proj1', ide: 'vscode', events: { cwd: true } });
+    config.setProject('proj2', { path: '/tmp/proj2', ide: 'vscode', events: { cwd: true } });
+
+    mockSelect
+      .mockResolvedValueOnce('switch-project')
+      .mockResolvedValueOnce('proj1');
+
+    await runInteractive({
+      config,
+      log: mockLog,
+      environment: new BaseEnvironment(),
+    });
+
+    // Should have called select with project choices
+    const projectSelectCall = mockSelect.mock.calls.find(
+      (call: unknown[]) =>
+        (call[0] as { message: string }).message === 'Select a project to open:'
+    );
+    expect(projectSelectCall).toBeDefined();
+
+    const choices = (projectSelectCall?.[0] as { choices: Array<{ value: string }> }).choices;
+    expect(choices.map((c) => c.value)).toContain('proj1');
+    expect(choices.map((c) => c.value)).toContain('proj2');
+  });
+
+  it('should not show branch configs in project list', async () => {
+    // Create test project and branch
+    config.setProject('proj1', { path: '/tmp/proj1', ide: 'vscode', events: { cwd: true } });
+    config.setProject('proj1#feature', {
+      path: '/tmp/proj1',
+      ide: 'vscode',
+      events: { cwd: true },
+      branch: 'feature',
+    });
+
+    mockSelect
+      .mockResolvedValueOnce('switch-project')
+      .mockResolvedValueOnce('proj1');
+
+    await runInteractive({
+      config,
+      log: mockLog,
+      environment: new BaseEnvironment(),
+    });
+
+    const projectSelectCall = mockSelect.mock.calls.find(
+      (call: unknown[]) =>
+        (call[0] as { message: string }).message === 'Select a project to open:'
+    );
+
+    const choices = (projectSelectCall?.[0] as { choices: Array<{ value: string }> }).choices;
+    expect(choices.map((c) => c.value)).not.toContain('proj1#feature');
+
+    config.deleteProject('proj1#feature');
+  });
+});
+
+describe('switch-branch flow', () => {
+  let config: Config;
+  let mockLog: {
+    debug: ReturnType<typeof vi.fn>;
+    info: ReturnType<typeof vi.fn>;
+    log: ReturnType<typeof vi.fn>;
+    warn: ReturnType<typeof vi.fn>;
+    error: ReturnType<typeof vi.fn>;
+    setLogLevel: ReturnType<typeof vi.fn>;
+  };
+  let consoleSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    config = new Config();
+    mockLog = {
+      debug: vi.fn(),
+      info: vi.fn(),
+      log: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      setLogLevel: vi.fn(),
+    };
+    consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    mockSelect.mockReset();
+    mockInput.mockReset();
+    mockCheckbox.mockReset();
+    mockConfirm.mockReset();
+  });
+
+  afterEach(() => {
+    consoleSpy.mockRestore();
+    try {
+      config.deleteProject('testproj');
+      config.deleteProject('testproj#feature');
+      config.deleteProject('testproj#bugfix');
+    } catch {
+      // Ignore cleanup errors
+    }
+  });
+
+  it('should show message when no branches exist', async () => {
+    config.setProject('testproj', { path: '/tmp/testproj', ide: 'vscode', events: { cwd: true } });
+
+    const projectEnv = new ProjectEnvironment({
+      name: 'testproj',
+      path: '/tmp/testproj',
+      events: { cwd: true },
+    });
+
+    mockSelect.mockResolvedValueOnce('switch-branch');
+
+    await runInteractive({
+      config,
+      log: mockLog,
+      environment: projectEnv,
+    });
+
+    expect(mockLog.info).toHaveBeenCalledWith(
+      expect.stringContaining('No branch configurations found')
+    );
+  });
+
+  it('should list existing branches for selection', async () => {
+    config.setProject('testproj', { path: '/tmp/testproj', ide: 'vscode', events: { cwd: true } });
+    config.setProject('testproj#feature', {
+      path: '/tmp/testproj',
+      ide: 'vscode',
+      events: { cwd: true },
+      branch: 'feature',
+    });
+    config.setProject('testproj#bugfix', {
+      path: '/tmp/testproj',
+      ide: 'vscode',
+      events: { cwd: true },
+      branch: 'bugfix',
+    });
+
+    const projectEnv = new ProjectEnvironment({
+      name: 'testproj',
+      path: '/tmp/testproj',
+      events: { cwd: true },
+    });
+
+    mockSelect
+      .mockResolvedValueOnce('switch-branch')
+      .mockResolvedValueOnce('testproj#feature');
+
+    await runInteractive({
+      config,
+      log: mockLog,
+      environment: projectEnv,
+    });
+
+    const branchSelectCall = mockSelect.mock.calls.find(
+      (call: unknown[]) =>
+        (call[0] as { message: string }).message === 'Select a branch configuration:'
+    );
+    expect(branchSelectCall).toBeDefined();
+
+    const choices = (branchSelectCall?.[0] as { choices: Array<{ name: string; value: string }> })
+      .choices;
+    expect(choices.map((c) => c.name)).toContain('feature');
+    expect(choices.map((c) => c.name)).toContain('bugfix');
+  });
+});
+
+describe('manage-projects flow', () => {
+  let config: Config;
+  let mockLog: {
+    debug: ReturnType<typeof vi.fn>;
+    info: ReturnType<typeof vi.fn>;
+    log: ReturnType<typeof vi.fn>;
+    warn: ReturnType<typeof vi.fn>;
+    error: ReturnType<typeof vi.fn>;
+    setLogLevel: ReturnType<typeof vi.fn>;
+  };
+  let consoleSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    config = new Config();
+    mockLog = {
+      debug: vi.fn(),
+      info: vi.fn(),
+      log: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      setLogLevel: vi.fn(),
+    };
+    consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    mockSelect.mockReset();
+    mockInput.mockReset();
+    mockCheckbox.mockReset();
+    mockConfirm.mockReset();
+  });
+
+  afterEach(() => {
+    consoleSpy.mockRestore();
+    try {
+      config.deleteProject('manageproj');
+    } catch {
+      // Ignore cleanup errors
+    }
+  });
+
+  it('should show manage menu and return on back', async () => {
+    mockSelect
+      .mockResolvedValueOnce('manage-projects')
+      .mockResolvedValueOnce('back');
+
+    await runInteractive({
+      config,
+      log: mockLog,
+      environment: new BaseEnvironment(),
+    });
+
+    const manageMenuCall = mockSelect.mock.calls.find(
+      (call: unknown[]) => (call[0] as { message: string }).message === 'Manage projects:'
+    );
+    expect(manageMenuCall).toBeDefined();
+  });
+
+  it('should allow creating a project from manage menu', async () => {
+    mockSelect
+      .mockResolvedValueOnce('manage-projects')
+      .mockResolvedValueOnce('create')
+      .mockResolvedValueOnce('vscode') // IDE
+      .mockResolvedValueOnce('back'); // Back to main
+
+    mockInput
+      .mockResolvedValueOnce('manageproj') // name
+      .mockResolvedValueOnce('/tmp/manageproj'); // path
+
+    mockCheckbox.mockResolvedValueOnce(['cwd']);
+    mockConfirm.mockResolvedValueOnce(true); // Confirm save
+
+    await runInteractive({
+      config,
+      log: mockLog,
+      environment: new BaseEnvironment(),
+    });
+
+    const project = config.getProject('manageproj');
+    expect(project).toBeDefined();
+    expect(project?.ide).toBe('vscode');
+  });
+
+  it('should list projects from manage menu', async () => {
+    config.setProject('manageproj', { path: '/tmp/manageproj', ide: 'vscode', events: { cwd: true } });
+
+    mockSelect
+      .mockResolvedValueOnce('manage-projects')
+      .mockResolvedValueOnce('list')
+      .mockResolvedValueOnce('back');
+
+    await runInteractive({
+      config,
+      log: mockLog,
+      environment: new BaseEnvironment(),
+    });
+
+    // Should have logged project info
+    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('manageproj'));
+  });
+
+  it('should delete project from manage menu', async () => {
+    config.setProject('manageproj', { path: '/tmp/manageproj', ide: 'vscode', events: { cwd: true } });
+
+    mockSelect
+      .mockResolvedValueOnce('manage-projects')
+      .mockResolvedValueOnce('delete')
+      .mockResolvedValueOnce('manageproj') // Select project to delete
+      .mockResolvedValueOnce('back');
+
+    mockConfirm.mockResolvedValueOnce(true); // Confirm delete
+
+    await runInteractive({
+      config,
+      log: mockLog,
+      environment: new BaseEnvironment(),
+    });
+
+    const project = config.getProject('manageproj');
+    expect(project).toBeUndefined();
+  });
+});
+
+describe('manage-branches flow', () => {
+  let config: Config;
+  let mockLog: {
+    debug: ReturnType<typeof vi.fn>;
+    info: ReturnType<typeof vi.fn>;
+    log: ReturnType<typeof vi.fn>;
+    warn: ReturnType<typeof vi.fn>;
+    error: ReturnType<typeof vi.fn>;
+    setLogLevel: ReturnType<typeof vi.fn>;
+  };
+  let consoleSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    config = new Config();
+    mockLog = {
+      debug: vi.fn(),
+      info: vi.fn(),
+      log: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      setLogLevel: vi.fn(),
+    };
+    consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    mockSelect.mockReset();
+    mockInput.mockReset();
+    mockCheckbox.mockReset();
+    mockConfirm.mockReset();
+  });
+
+  afterEach(() => {
+    consoleSpy.mockRestore();
+    try {
+      config.deleteProject('branchproj');
+      config.deleteProject('branchproj#feature');
+      config.deleteProject('branchproj#bugfix');
+    } catch {
+      // Ignore cleanup errors
+    }
+  });
+
+  it('should show manage branches menu from project environment', async () => {
+    config.setProject('branchproj', { path: '/tmp/branchproj', ide: 'vscode', events: { cwd: true } });
+
+    const projectEnv = new ProjectEnvironment({
+      name: 'branchproj',
+      path: '/tmp/branchproj',
+      events: { cwd: true },
+    });
+
+    mockSelect
+      .mockResolvedValueOnce('manage-branches')
+      .mockResolvedValueOnce('back');
+
+    await runInteractive({
+      config,
+      log: mockLog,
+      environment: projectEnv,
+    });
+
+    const manageBranchesCall = mockSelect.mock.calls.find(
+      (call: unknown[]) =>
+        (call[0] as { message: string }).message === "Manage branches for 'branchproj':"
+    );
+    expect(manageBranchesCall).toBeDefined();
+  });
+
+  it('should create new branch config from manage branches', async () => {
+    config.setProject('branchproj', { path: '/tmp/branchproj', ide: 'vscode', events: { cwd: true } });
+
+    const projectEnv = new ProjectEnvironment({
+      name: 'branchproj',
+      path: '/tmp/branchproj',
+      events: { cwd: true },
+    });
+
+    mockSelect
+      .mockResolvedValueOnce('manage-branches')
+      .mockResolvedValueOnce('create')
+      .mockResolvedValueOnce('back');
+
+    mockInput.mockResolvedValueOnce('feature'); // Branch name
+
+    await runInteractive({
+      config,
+      log: mockLog,
+      environment: projectEnv,
+    });
+
+    const branch = config.getProject('branchproj#feature');
+    expect(branch).toBeDefined();
+  });
+
+  it('should list branches from manage branches menu', async () => {
+    config.setProject('branchproj', { path: '/tmp/branchproj', ide: 'vscode', events: { cwd: true } });
+    config.setProject('branchproj#feature', {
+      path: '/tmp/branchproj',
+      ide: 'vscode',
+      events: { cwd: true },
+      branch: 'feature',
+    });
+
+    const projectEnv = new ProjectEnvironment({
+      name: 'branchproj',
+      path: '/tmp/branchproj',
+      events: { cwd: true },
+    });
+
+    mockSelect
+      .mockResolvedValueOnce('manage-branches')
+      .mockResolvedValueOnce('list')
+      .mockResolvedValueOnce('back');
+
+    await runInteractive({
+      config,
+      log: mockLog,
+      environment: projectEnv,
+    });
+
+    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('feature'));
+  });
+
+  it('should delete branch config from manage branches', async () => {
+    config.setProject('branchproj', { path: '/tmp/branchproj', ide: 'vscode', events: { cwd: true } });
+    config.setProject('branchproj#feature', {
+      path: '/tmp/branchproj',
+      ide: 'vscode',
+      events: { cwd: true },
+      branch: 'feature',
+    });
+
+    const projectEnv = new ProjectEnvironment({
+      name: 'branchproj',
+      path: '/tmp/branchproj',
+      events: { cwd: true },
+    });
+
+    mockSelect
+      .mockResolvedValueOnce('manage-branches')
+      .mockResolvedValueOnce('delete')
+      .mockResolvedValueOnce('branchproj#feature') // Select branch to delete
+      .mockResolvedValueOnce('back');
+
+    mockConfirm.mockResolvedValueOnce(true); // Confirm delete
+
+    await runInteractive({
+      config,
+      log: mockLog,
+      environment: projectEnv,
+    });
+
+    const branch = config.getProject('branchproj#feature');
+    expect(branch).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary

- Fix critical bug where `workon {projectName}` rejected arguments with "too many arguments" error
- Implement all previously stubbed interactive menu features:
  - **switch-project**: List and open existing projects
  - **switch-branch**: List and open branch configurations for current project
  - **manage-projects**: Full CRUD (create/edit/delete/list) for projects
  - **manage-branches**: Full CRUD for branch configurations

## Changes

| File | Description |
|------|-------------|
| `src/commands/index.ts` | Add `[project]` argument to main CLI command |
| `src/commands/interactive.ts` | Implement 4 previously stubbed features (~530 new lines) |
| `tests/commands/cli-index.test.ts` | New test file for CLI structure (12 tests) |
| `tests/commands/interactive.test.ts` | Extended with 13 new tests for interactive features |

## Test plan

- [x] All 344 tests pass
- [x] `workon {projectName}` now correctly opens projects
- [x] Interactive menu options work end-to-end
- [x] Build succeeds with no lint errors

🤖 Generated with [Claude Code](https://claude.ai/code)