### PR TITLE
security: add shell command sanitization for project names

### DIFF
--- a/src/lib/sanitize.ts
+++ b/src/lib/sanitize.ts
@@ -1,0 +1,34 @@
+/**
+ * Shell command sanitization utilities.
+ * Prevents shell injection attacks from malicious project names or paths.
+ */
+
+/**
+ * Sanitize a string for safe use as a shell identifier (e.g., tmux session name).
+ * Only allows alphanumeric characters, underscores, hyphens, and dots.
+ * All other characters are replaced with underscores.
+ */
+export function sanitizeForShell(input: string): string {
+  if (!input) return '';
+  return input.replace(/[^a-zA-Z0-9_\-.]/g, '_');
+}
+
+/**
+ * Escape a string for safe use in a double-quoted shell context.
+ * Escapes characters that have special meaning in double quotes: $, `, \, ", !
+ */
+export function escapeShellArg(input: string): string {
+  if (!input) return '';
+  return input.replace(/([\\$`"!])/g, '\\$1');
+}
+
+/**
+ * Escape a string for safe use in a single-quoted shell context.
+ * Single quotes prevent all interpolation, but we need to handle
+ * embedded single quotes by ending the string, adding an escaped quote,
+ * and restarting the string.
+ */
+export function escapeForSingleQuotes(input: string): string {
+  if (!input) return '';
+  return input.replace(/'/g, "'\\''");
+}

--- a/src/lib/tmux.ts
+++ b/src/lib/tmux.ts
@@ -1,5 +1,6 @@
 import { exec as execCallback, spawn } from 'child_process';
 import { promisify } from 'util';
+import { sanitizeForShell, escapeForSingleQuotes } from './sanitize.js';
 
 const exec = promisify(execCallback);
 
@@ -17,7 +18,8 @@ export class TmuxManager {
 
   async sessionExists(sessionName: string): Promise<boolean> {
     try {
-      await exec(`tmux has-session -t "${sessionName}"`);
+      // sessionName is already sanitized by getSessionName
+      await exec(`tmux has-session -t '${escapeForSingleQuotes(sessionName)}'`);
       return true;
     } catch {
       return false;
@@ -25,12 +27,13 @@ export class TmuxManager {
   }
 
   getSessionName(projectName: string): string {
-    return `${this.sessionPrefix}${projectName}`;
+    // Sanitize project name to prevent shell injection
+    return `${this.sessionPrefix}${sanitizeForShell(projectName)}`;
   }
 
   async killSession(sessionName: string): Promise<boolean> {
     try {
-      await exec(`tmux kill-session -t "${sessionName}"`);
+      await exec(`tmux kill-session -t '${escapeForSingleQuotes(sessionName)}'`);
       return true;
     } catch {
       return false;
@@ -43,6 +46,8 @@ export class TmuxManager {
     claudeArgs: string[] = []
   ): Promise<string> {
     const sessionName = this.getSessionName(projectName);
+    const escapedSession = escapeForSingleQuotes(sessionName);
+    const escapedPath = escapeForSingleQuotes(projectPath);
 
     // Kill existing session if it exists
     if (await this.sessionExists(sessionName)) {
@@ -50,15 +55,18 @@ export class TmuxManager {
     }
 
     const claudeCommand = claudeArgs.length > 0 ? `claude ${claudeArgs.join(' ')}` : 'claude';
+    const escapedClaudeCmd = escapeForSingleQuotes(claudeCommand);
 
     // Create new tmux session with claude in the first pane
-    await exec(`tmux new-session -d -s "${sessionName}" -c "${projectPath}" '${claudeCommand}'`);
+    await exec(
+      `tmux new-session -d -s '${escapedSession}' -c '${escapedPath}' '${escapedClaudeCmd}'`
+    );
 
     // Split window horizontally and run shell in second pane
-    await exec(`tmux split-window -h -t "${sessionName}" -c "${projectPath}"`);
+    await exec(`tmux split-window -h -t '${escapedSession}' -c '${escapedPath}'`);
 
     // Set focus on claude pane (left pane)
-    await exec(`tmux select-pane -t "${sessionName}:0.0"`);
+    await exec(`tmux select-pane -t '${escapedSession}:0.0'`);
 
     return sessionName;
   }
@@ -70,6 +78,8 @@ export class TmuxManager {
     npmCommand = 'npm run dev'
   ): Promise<string> {
     const sessionName = this.getSessionName(projectName);
+    const escapedSession = escapeForSingleQuotes(sessionName);
+    const escapedPath = escapeForSingleQuotes(projectPath);
 
     // Kill existing session if it exists
     if (await this.sessionExists(sessionName)) {
@@ -77,24 +87,30 @@ export class TmuxManager {
     }
 
     const claudeCommand = claudeArgs.length > 0 ? `claude ${claudeArgs.join(' ')}` : 'claude';
+    const escapedClaudeCmd = escapeForSingleQuotes(claudeCommand);
+    const escapedNpmCmd = escapeForSingleQuotes(npmCommand);
 
     // Create new tmux session with claude in the first pane (left side)
-    await exec(`tmux new-session -d -s "${sessionName}" -c "${projectPath}" '${claudeCommand}'`);
+    await exec(
+      `tmux new-session -d -s '${escapedSession}' -c '${escapedPath}' '${escapedClaudeCmd}'`
+    );
 
     // Split window vertically - creates right side (50/50 split)
-    await exec(`tmux split-window -h -t "${sessionName}" -c "${projectPath}"`);
+    await exec(`tmux split-window -h -t '${escapedSession}' -c '${escapedPath}'`);
 
     // Split the right pane horizontally - creates top-right and bottom-right (50/50 split)
-    await exec(`tmux split-window -v -t "${sessionName}:0.1" -c "${projectPath}" '${npmCommand}'`);
+    await exec(
+      `tmux split-window -v -t '${escapedSession}:0.1' -c '${escapedPath}' '${escapedNpmCmd}'`
+    );
 
     // Set remain-on-exit to keep pane open if command fails
-    await exec(`tmux set-option -t "${sessionName}:0.2" remain-on-exit on`);
+    await exec(`tmux set-option -t '${escapedSession}:0.2' remain-on-exit on`);
 
     // Resize panes to ensure npm pane is visible (give it at least 10 lines)
-    await exec(`tmux resize-pane -t "${sessionName}:0.2" -y 10`);
+    await exec(`tmux resize-pane -t '${escapedSession}:0.2' -y 10`);
 
     // Set focus on claude pane (left pane)
-    await exec(`tmux select-pane -t "${sessionName}:0.0"`);
+    await exec(`tmux select-pane -t '${escapedSession}:0.0'`);
 
     return sessionName;
   }
@@ -105,6 +121,9 @@ export class TmuxManager {
     npmCommand = 'npm run dev'
   ): Promise<string> {
     const sessionName = this.getSessionName(projectName);
+    const escapedSession = escapeForSingleQuotes(sessionName);
+    const escapedPath = escapeForSingleQuotes(projectPath);
+    const escapedNpmCmd = escapeForSingleQuotes(npmCommand);
 
     // Kill existing session if it exists
     if (await this.sessionExists(sessionName)) {
@@ -112,25 +131,29 @@ export class TmuxManager {
     }
 
     // Create new tmux session with shell in the first pane (left side)
-    await exec(`tmux new-session -d -s "${sessionName}" -c "${projectPath}"`);
+    await exec(`tmux new-session -d -s '${escapedSession}' -c '${escapedPath}'`);
 
     // Split window vertically and run npm command in right pane
-    await exec(`tmux split-window -h -t "${sessionName}" -c "${projectPath}" '${npmCommand}'`);
+    await exec(
+      `tmux split-window -h -t '${escapedSession}' -c '${escapedPath}' '${escapedNpmCmd}'`
+    );
 
     // Set remain-on-exit to keep pane open if command fails
-    await exec(`tmux set-option -t "${sessionName}:0.1" remain-on-exit on`);
+    await exec(`tmux set-option -t '${escapedSession}:0.1' remain-on-exit on`);
 
     // Set focus on terminal pane (left pane)
-    await exec(`tmux select-pane -t "${sessionName}:0.0"`);
+    await exec(`tmux select-pane -t '${escapedSession}:0.0'`);
 
     return sessionName;
   }
 
   async attachToSession(sessionName: string): Promise<void> {
+    const escapedSession = escapeForSingleQuotes(sessionName);
+
     // Check if we're already in a tmux session
     if (process.env.TMUX) {
       // If we're already in tmux, switch to the session
-      await exec(`tmux switch-client -t "${sessionName}"`);
+      await exec(`tmux switch-client -t '${escapedSession}'`);
     } else {
       // Check if iTerm2 integration is available
       const isITerm =
@@ -161,14 +184,17 @@ export class TmuxManager {
     claudeArgs: string[] = []
   ): string[] {
     const sessionName = this.getSessionName(projectName);
+    const escapedSession = escapeForSingleQuotes(sessionName);
+    const escapedPath = escapeForSingleQuotes(projectPath);
     const claudeCommand = claudeArgs.length > 0 ? `claude ${claudeArgs.join(' ')}` : 'claude';
+    const escapedClaudeCmd = escapeForSingleQuotes(claudeCommand);
 
     return [
-      `# Create tmux split session for ${projectName}`,
-      `tmux has-session -t "${sessionName}" 2>/dev/null && tmux kill-session -t "${sessionName}"`,
-      `tmux new-session -d -s "${sessionName}" -c "${projectPath}" '${claudeCommand}'`,
-      `tmux split-window -h -t "${sessionName}" -c "${projectPath}"`,
-      `tmux select-pane -t "${sessionName}:0.0"`,
+      `# Create tmux split session for ${sanitizeForShell(projectName)}`,
+      `tmux has-session -t '${escapedSession}' 2>/dev/null && tmux kill-session -t '${escapedSession}'`,
+      `tmux new-session -d -s '${escapedSession}' -c '${escapedPath}' '${escapedClaudeCmd}'`,
+      `tmux split-window -h -t '${escapedSession}' -c '${escapedPath}'`,
+      `tmux select-pane -t '${escapedSession}:0.0'`,
       this.getAttachCommand(sessionName),
     ];
   }
@@ -180,17 +206,21 @@ export class TmuxManager {
     npmCommand = 'npm run dev'
   ): string[] {
     const sessionName = this.getSessionName(projectName);
+    const escapedSession = escapeForSingleQuotes(sessionName);
+    const escapedPath = escapeForSingleQuotes(projectPath);
     const claudeCommand = claudeArgs.length > 0 ? `claude ${claudeArgs.join(' ')}` : 'claude';
+    const escapedClaudeCmd = escapeForSingleQuotes(claudeCommand);
+    const escapedNpmCmd = escapeForSingleQuotes(npmCommand);
 
     return [
-      `# Create tmux three-pane session for ${projectName}`,
-      `tmux has-session -t "${sessionName}" 2>/dev/null && tmux kill-session -t "${sessionName}"`,
-      `tmux new-session -d -s "${sessionName}" -c "${projectPath}" '${claudeCommand}'`,
-      `tmux split-window -h -t "${sessionName}" -c "${projectPath}"`,
-      `tmux split-window -v -t "${sessionName}:0.1" -c "${projectPath}" '${npmCommand}'`,
-      `tmux set-option -t "${sessionName}:0.2" remain-on-exit on`,
-      `tmux resize-pane -t "${sessionName}:0.2" -y 10`,
-      `tmux select-pane -t "${sessionName}:0.0"`,
+      `# Create tmux three-pane session for ${sanitizeForShell(projectName)}`,
+      `tmux has-session -t '${escapedSession}' 2>/dev/null && tmux kill-session -t '${escapedSession}'`,
+      `tmux new-session -d -s '${escapedSession}' -c '${escapedPath}' '${escapedClaudeCmd}'`,
+      `tmux split-window -h -t '${escapedSession}' -c '${escapedPath}'`,
+      `tmux split-window -v -t '${escapedSession}:0.1' -c '${escapedPath}' '${escapedNpmCmd}'`,
+      `tmux set-option -t '${escapedSession}:0.2' remain-on-exit on`,
+      `tmux resize-pane -t '${escapedSession}:0.2' -y 10`,
+      `tmux select-pane -t '${escapedSession}:0.0'`,
       this.getAttachCommand(sessionName),
     ];
   }
@@ -201,21 +231,26 @@ export class TmuxManager {
     npmCommand = 'npm run dev'
   ): string[] {
     const sessionName = this.getSessionName(projectName);
+    const escapedSession = escapeForSingleQuotes(sessionName);
+    const escapedPath = escapeForSingleQuotes(projectPath);
+    const escapedNpmCmd = escapeForSingleQuotes(npmCommand);
 
     return [
-      `# Create tmux two-pane session with npm for ${projectName}`,
-      `tmux has-session -t "${sessionName}" 2>/dev/null && tmux kill-session -t "${sessionName}"`,
-      `tmux new-session -d -s "${sessionName}" -c "${projectPath}"`,
-      `tmux split-window -h -t "${sessionName}" -c "${projectPath}" '${npmCommand}'`,
-      `tmux set-option -t "${sessionName}:0.1" remain-on-exit on`,
-      `tmux select-pane -t "${sessionName}:0.0"`,
+      `# Create tmux two-pane session with npm for ${sanitizeForShell(projectName)}`,
+      `tmux has-session -t '${escapedSession}' 2>/dev/null && tmux kill-session -t '${escapedSession}'`,
+      `tmux new-session -d -s '${escapedSession}' -c '${escapedPath}'`,
+      `tmux split-window -h -t '${escapedSession}' -c '${escapedPath}' '${escapedNpmCmd}'`,
+      `tmux set-option -t '${escapedSession}:0.1' remain-on-exit on`,
+      `tmux select-pane -t '${escapedSession}:0.0'`,
       this.getAttachCommand(sessionName),
     ];
   }
 
   private getAttachCommand(sessionName: string): string {
+    const escapedSession = escapeForSingleQuotes(sessionName);
+
     if (process.env.TMUX) {
-      return `tmux switch-client -t "${sessionName}"`;
+      return `tmux switch-client -t '${escapedSession}'`;
     }
 
     const isITerm =
@@ -225,9 +260,9 @@ export class TmuxManager {
     const useiTermIntegration = isITerm && !process.env.TMUX_CC_NOT_SUPPORTED;
 
     if (useiTermIntegration) {
-      return `tmux -CC attach-session -t "${sessionName}"`;
+      return `tmux -CC attach-session -t '${escapedSession}'`;
     }
-    return `tmux attach-session -t "${sessionName}"`;
+    return `tmux attach-session -t '${escapedSession}'`;
   }
 
   async listWorkonSessions(): Promise<string[]> {

--- a/tests/lib/sanitize.test.ts
+++ b/tests/lib/sanitize.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from 'vitest';
+import {
+  sanitizeForShell,
+  escapeShellArg,
+  escapeForSingleQuotes,
+} from '../../src/lib/sanitize.js';
+
+describe('sanitizeForShell', () => {
+  it('should allow alphanumeric characters', () => {
+    expect(sanitizeForShell('myProject123')).toBe('myProject123');
+  });
+
+  it('should allow underscores', () => {
+    expect(sanitizeForShell('my_project')).toBe('my_project');
+  });
+
+  it('should allow hyphens', () => {
+    expect(sanitizeForShell('my-project')).toBe('my-project');
+  });
+
+  it('should allow dots', () => {
+    expect(sanitizeForShell('my.project')).toBe('my.project');
+  });
+
+  it('should replace spaces with underscores', () => {
+    expect(sanitizeForShell('my project')).toBe('my_project');
+  });
+
+  it('should replace special shell characters with underscores', () => {
+    expect(sanitizeForShell('project$evil')).toBe('project_evil');
+    expect(sanitizeForShell('project`cmd`')).toBe('project_cmd_');
+    expect(sanitizeForShell('project;rm -rf')).toBe('project_rm_-rf'); // hyphen is allowed
+    expect(sanitizeForShell('project|cat')).toBe('project_cat');
+    expect(sanitizeForShell('project&bg')).toBe('project_bg');
+  });
+
+  it('should replace quotes with underscores', () => {
+    expect(sanitizeForShell("project'name")).toBe('project_name');
+    expect(sanitizeForShell('project"name')).toBe('project_name');
+  });
+
+  it('should handle empty string', () => {
+    expect(sanitizeForShell('')).toBe('');
+  });
+
+  it('should handle string with only special characters', () => {
+    expect(sanitizeForShell('$`|&;')).toBe('_____');
+  });
+
+  it('should handle unicode characters', () => {
+    expect(sanitizeForShell('project🚀name')).toBe('project__name');
+  });
+});
+
+describe('escapeShellArg', () => {
+  it('should escape dollar signs', () => {
+    expect(escapeShellArg('$HOME')).toBe('\\$HOME');
+  });
+
+  it('should escape backticks', () => {
+    expect(escapeShellArg('`whoami`')).toBe('\\`whoami\\`');
+  });
+
+  it('should escape backslashes', () => {
+    expect(escapeShellArg('path\\to\\file')).toBe('path\\\\to\\\\file');
+  });
+
+  it('should escape double quotes', () => {
+    expect(escapeShellArg('say "hello"')).toBe('say \\"hello\\"');
+  });
+
+  it('should escape exclamation marks', () => {
+    expect(escapeShellArg('hello!')).toBe('hello\\!');
+  });
+
+  it('should handle multiple special characters', () => {
+    expect(escapeShellArg('$HOME/`cmd`!"test"')).toBe('\\$HOME/\\`cmd\\`\\!\\"test\\"');
+  });
+
+  it('should handle empty string', () => {
+    expect(escapeShellArg('')).toBe('');
+  });
+
+  it('should leave safe characters unchanged', () => {
+    expect(escapeShellArg('safe-path_123.txt')).toBe('safe-path_123.txt');
+  });
+});
+
+describe('escapeForSingleQuotes', () => {
+  it('should escape single quotes', () => {
+    expect(escapeForSingleQuotes("it's")).toBe("it'\\''s");
+  });
+
+  it('should handle multiple single quotes', () => {
+    expect(escapeForSingleQuotes("it's a 'test'")).toBe("it'\\''s a '\\''test'\\''");
+  });
+
+  it('should handle empty string', () => {
+    expect(escapeForSingleQuotes('')).toBe('');
+  });
+
+  it('should leave strings without single quotes unchanged', () => {
+    expect(escapeForSingleQuotes('no quotes here')).toBe('no quotes here');
+  });
+
+  it('should leave special characters (except single quote) unchanged', () => {
+    // In single quotes, special chars are literal
+    expect(escapeForSingleQuotes('$HOME `cmd`')).toBe('$HOME `cmd`');
+  });
+});

--- a/tests/lib/tmux.test.ts
+++ b/tests/lib/tmux.test.ts
@@ -17,6 +17,12 @@ describe('TmuxManager', () => {
       expect(tmux.getSessionName('my-project')).toBe('workon-my-project');
       expect(tmux.getSessionName('my_project')).toBe('workon-my_project');
     });
+
+    it('should sanitize dangerous characters in project name', () => {
+      expect(tmux.getSessionName('project$evil')).toBe('workon-project_evil');
+      expect(tmux.getSessionName('project;rm')).toBe('workon-project_rm');
+      expect(tmux.getSessionName("project'name")).toBe('workon-project_name');
+    });
   });
 
   describe('buildShellCommands', () => {
@@ -29,15 +35,15 @@ describe('TmuxManager', () => {
 
       expect(commands).toContain('# Create tmux split session for myproject');
       expect(commands).toContain(
-        'tmux has-session -t "workon-myproject" 2>/dev/null && tmux kill-session -t "workon-myproject"'
+        "tmux has-session -t 'workon-myproject' 2>/dev/null && tmux kill-session -t 'workon-myproject'"
       );
       expect(commands).toContain(
-        `tmux new-session -d -s "workon-myproject" -c "/path/to/project" 'claude'`
+        "tmux new-session -d -s 'workon-myproject' -c '/path/to/project' 'claude'"
       );
       expect(commands).toContain(
-        'tmux split-window -h -t "workon-myproject" -c "/path/to/project"'
+        "tmux split-window -h -t 'workon-myproject' -c '/path/to/project'"
       );
-      expect(commands).toContain('tmux select-pane -t "workon-myproject:0.0"');
+      expect(commands).toContain("tmux select-pane -t 'workon-myproject:0.0'");
     });
 
     it('should include claude flags when provided', () => {
@@ -47,7 +53,7 @@ describe('TmuxManager', () => {
       ]);
 
       expect(commands).toContain(
-        `tmux new-session -d -s "workon-myproject" -c "/path/to/project" 'claude --model opus'`
+        "tmux new-session -d -s 'workon-myproject' -c '/path/to/project' 'claude --model opus'"
       );
     });
 
@@ -61,7 +67,7 @@ describe('TmuxManager', () => {
       vi.stubEnv('TMUX', '/tmp/tmux-123/default,456,0');
       const newTmux = new TmuxManager();
       const commands = newTmux.buildShellCommands('myproject', '/path/to/project');
-      expect(commands).toContain('tmux switch-client -t "workon-myproject"');
+      expect(commands).toContain("tmux switch-client -t 'workon-myproject'");
     });
   });
 
@@ -75,10 +81,10 @@ describe('TmuxManager', () => {
 
       expect(commands).toContain('# Create tmux three-pane session for myproject');
       expect(commands).toContain(
-        'tmux split-window -v -t "workon-myproject:0.1" -c "/path/to/project" \'npm run dev\''
+        "tmux split-window -v -t 'workon-myproject:0.1' -c '/path/to/project' 'npm run dev'"
       );
-      expect(commands).toContain('tmux set-option -t "workon-myproject:0.2" remain-on-exit on');
-      expect(commands).toContain('tmux resize-pane -t "workon-myproject:0.2" -y 10');
+      expect(commands).toContain("tmux set-option -t 'workon-myproject:0.2' remain-on-exit on");
+      expect(commands).toContain("tmux resize-pane -t 'workon-myproject:0.2' -y 10");
     });
 
     it('should use custom npm command', () => {
@@ -89,9 +95,7 @@ describe('TmuxManager', () => {
         'pnpm run start'
       );
 
-      expect(
-        commands.some((c) => c.includes("'pnpm run start'"))
-      ).toBe(true);
+      expect(commands.some((c) => c.includes("'pnpm run start'"))).toBe(true);
     });
 
     it('should include claude flags', () => {
@@ -100,7 +104,7 @@ describe('TmuxManager', () => {
       ]);
 
       expect(commands).toContain(
-        `tmux new-session -d -s "workon-myproject" -c "/path/to/project" 'claude --resume'`
+        "tmux new-session -d -s 'workon-myproject' -c '/path/to/project' 'claude --resume'"
       );
     });
   });
@@ -110,11 +114,13 @@ describe('TmuxManager', () => {
       const commands = tmux.buildTwoPaneNpmShellCommands('myproject', '/path/to/project');
 
       expect(commands).toContain('# Create tmux two-pane session with npm for myproject');
-      expect(commands).toContain('tmux new-session -d -s "workon-myproject" -c "/path/to/project"');
       expect(commands).toContain(
-        `tmux split-window -h -t "workon-myproject" -c "/path/to/project" 'npm run dev'`
+        "tmux new-session -d -s 'workon-myproject' -c '/path/to/project'"
       );
-      expect(commands).toContain('tmux set-option -t "workon-myproject:0.1" remain-on-exit on');
+      expect(commands).toContain(
+        "tmux split-window -h -t 'workon-myproject' -c '/path/to/project' 'npm run dev'"
+      );
+      expect(commands).toContain("tmux set-option -t 'workon-myproject:0.1' remain-on-exit on");
     });
 
     it('should use custom npm command', () => {
@@ -139,7 +145,7 @@ describe('TmuxManager', () => {
 
       const newTmux = new TmuxManager();
       const commands = newTmux.buildShellCommands('myproject', '/path/to/project');
-      expect(commands).toContain('tmux -CC attach-session -t "workon-myproject"');
+      expect(commands).toContain("tmux -CC attach-session -t 'workon-myproject'");
     });
 
     it('should use -CC flag for iTerm when LC_TERMINAL is set', () => {
@@ -148,7 +154,7 @@ describe('TmuxManager', () => {
 
       const newTmux = new TmuxManager();
       const commands = newTmux.buildShellCommands('myproject', '/path/to/project');
-      expect(commands).toContain('tmux -CC attach-session -t "workon-myproject"');
+      expect(commands).toContain("tmux -CC attach-session -t 'workon-myproject'");
     });
 
     it('should use -CC flag for iTerm when ITERM_SESSION_ID is set', () => {
@@ -157,7 +163,7 @@ describe('TmuxManager', () => {
 
       const newTmux = new TmuxManager();
       const commands = newTmux.buildShellCommands('myproject', '/path/to/project');
-      expect(commands).toContain('tmux -CC attach-session -t "workon-myproject"');
+      expect(commands).toContain("tmux -CC attach-session -t 'workon-myproject'");
     });
 
     it('should not use -CC flag when TMUX_CC_NOT_SUPPORTED is set', () => {
@@ -167,8 +173,8 @@ describe('TmuxManager', () => {
 
       const newTmux = new TmuxManager();
       const commands = newTmux.buildShellCommands('myproject', '/path/to/project');
-      expect(commands).not.toContain('tmux -CC attach-session -t "workon-myproject"');
-      expect(commands).toContain('tmux attach-session -t "workon-myproject"');
+      expect(commands).not.toContain("tmux -CC attach-session -t 'workon-myproject'");
+      expect(commands).toContain("tmux attach-session -t 'workon-myproject'");
     });
   });
 });


### PR DESCRIPTION
## Summary
- Add src/lib/sanitize.ts with utilities to prevent shell injection attacks
- sanitizeForShell(): Removes dangerous characters from session names
- escapeForSingleQuotes(): Safely escapes strings for single-quoted shell context
- Update TmuxManager to sanitize all project names and escape shell arguments
- Use single quotes consistently for better security (prevents variable interpolation)

## Security Improvements
Project names with special characters are now sanitized to safe identifiers before being used in shell commands.

## Test plan
- [x] Type check passes
- [x] All 368 tests pass
- [x] New tests for sanitization functions added
- [x] Updated tmux tests to reflect new quoting style

Generated with Claude Code