### PR TITLE
refactor: centralize EventRegistry initialization in CLI preAction hook

### DIFF
--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -7,6 +7,7 @@ import omelette from 'omelette';
 import File from 'phylo';
 import { Config } from '../lib/config.js';
 import { EnvironmentRecognizer } from '../lib/environment.js';
+import { EventRegistry } from '../events/registry.js';
 import { createOpenCommand } from './open.js';
 import { createConfigCommand } from './config/index.js';
 import { createManageCommand } from './manage.js';
@@ -69,11 +70,13 @@ export function createCli(): Command {
     .option('--completion', 'Setup shell tab completion')
     .option('--shell', 'Output shell commands for evaluation')
     .option('--init', 'Generate shell integration function')
-    .hook('preAction', (thisCommand) => {
+    .hook('preAction', async (thisCommand) => {
       const opts = thisCommand.opts<GlobalOptions>();
       if (opts.debug) {
         log.setLogLevel('debug');
       }
+      // Initialize event registry once before any command runs
+      await EventRegistry.initialize();
     })
     .action(
       async (

--- a/src/commands/interactive.ts
+++ b/src/commands/interactive.ts
@@ -307,9 +307,6 @@ async function switchBranch(projectName: string, ctx: InteractiveContext): Promi
 async function manageProjects(ctx: InteractiveContext): Promise<void> {
   const { config } = ctx;
 
-  // Initialize event registry for manage operations
-  await EventRegistry.initialize();
-
   const projects = config.getProjects();
   const hasProjects = Object.keys(projects).length > 0;
 
@@ -405,9 +402,6 @@ async function openProject(projectName: string, ctx: InteractiveContext): Promis
     log.error(`Project '${projectName}' not found.`);
     return;
   }
-
-  // Initialize event registry if needed
-  await EventRegistry.initialize();
 
   const projectConfig = projects[projectName];
   const projectCfg = { ...projectConfig, name: projectName };

--- a/src/commands/manage.ts
+++ b/src/commands/manage.ts
@@ -22,7 +22,6 @@ export function createManageCommand(ctx: ManageContext): Command {
         log.setLogLevel('debug');
       }
 
-      await EventRegistry.initialize();
       await mainMenu(ctx);
     });
 }

--- a/src/commands/open.ts
+++ b/src/commands/open.ts
@@ -37,9 +37,6 @@ export function createOpenCommand(ctx: OpenContext): Command {
         log.setLogLevel('debug');
       }
 
-      // Initialize event registry
-      await EventRegistry.initialize();
-
       if (projectArg) {
         await processProject(projectArg, options, ctx);
       } else {

--- a/tests/commands/interactive.test.ts
+++ b/tests/commands/interactive.test.ts
@@ -33,6 +33,7 @@ vi.mock('child_process', () => ({
 
 // Import after mocking
 import { runInteractive } from '../../src/commands/interactive.js';
+import { EventRegistry } from '../../src/events/registry.js';
 
 describe('interactive command', () => {
   let config: Config;
@@ -46,8 +47,12 @@ describe('interactive command', () => {
   };
   let consoleSpy: ReturnType<typeof vi.spyOn>;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     config = new Config();
+
+    // Initialize event registry before tests
+    EventRegistry.clear();
+    await EventRegistry.initialize();
 
     mockLog = {
       debug: vi.fn(),


### PR DESCRIPTION
## Summary
- Move `EventRegistry.initialize()` from 4 scattered locations to a single preAction hook in the CLI entry point
- Ensures EventRegistry is initialized exactly once before any command runs
- Commands no longer need to worry about initialization order

## Changes
- `index.ts`: Add async preAction hook that initializes EventRegistry
- `open.ts`: Remove EventRegistry.initialize() call
- `interactive.ts`: Remove 2 EventRegistry.initialize() calls
- `manage.ts`: Remove EventRegistry.initialize() call
- `interactive.test.ts`: Add EventRegistry init to test setup (tests call runInteractive directly)

## Test plan
- [x] Type check passes
- [x] All 368 tests pass

Generated with Claude Code