### PR TITLE
fix: improve shell mode and tmux -CC integration

### DIFF
--- a/src/commands/add.ts
+++ b/src/commands/add.ts
@@ -22,6 +22,7 @@ interface ProjectDiscovery {
   name: string;
   isNode: boolean;
   isBun: boolean;
+  hasClaude: boolean;
   detectedIde: IdeType | null;
   packageJson: Record<string, unknown> | null;
 }
@@ -104,7 +105,7 @@ async function addProject(pathArg: string, options: AddOptions, ctx: AddContext)
   }
 
   // Determine IDE
-  const ide: IdeType = options.ide || discovery.detectedIde || 'vscode';
+  const ide: IdeType = options.ide || discovery.detectedIde || 'code';
   log.debug(`IDE: ${ide}`);
 
   // Calculate relative path if possible
@@ -140,6 +141,11 @@ async function addProject(pathArg: string, options: AddOptions, ctx: AddContext)
     }
   }
 
+  // Add claude event if CLAUDE.md is detected
+  if (discovery.hasClaude) {
+    projectConfig.events.claude = true;
+  }
+
   // Save the project
   config.setProject(projectName, projectConfig);
 
@@ -159,6 +165,7 @@ function discoverProject(targetPath: string, log: Logger): ProjectDiscovery {
     name: dirName,
     isNode: false,
     isBun: false,
+    hasClaude: false,
     detectedIde: null,
     packageJson: null,
   };
@@ -193,14 +200,25 @@ function discoverProject(targetPath: string, log: Logger): ProjectDiscovery {
 
   // Detect IDE from config directories
   const vscodeDir = resolve(targetPath, '.vscode');
+  const cursorDir = resolve(targetPath, '.cursor');
   const ideaDir = resolve(targetPath, '.idea');
 
-  if (existsSync(vscodeDir)) {
-    discovery.detectedIde = 'vscode';
+  if (existsSync(cursorDir)) {
+    discovery.detectedIde = 'cursor';
+    log.debug('Detected Cursor (.cursor directory found)');
+  } else if (existsSync(vscodeDir)) {
+    discovery.detectedIde = 'code';
     log.debug('Detected VS Code (.vscode directory found)');
   } else if (existsSync(ideaDir)) {
     discovery.detectedIde = 'idea';
     log.debug('Detected IntelliJ IDEA (.idea directory found)');
+  }
+
+  // Detect Claude Code project
+  const claudeMdPath = resolve(targetPath, 'CLAUDE.md');
+  if (existsSync(claudeMdPath)) {
+    discovery.hasClaude = true;
+    log.debug('Detected Claude Code project (CLAUDE.md found)');
   }
 
   return discovery;

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -65,6 +65,7 @@ export function createCli(): Command {
     .name('workon')
     .description('Work on something great!')
     .version(packageJson.version)
+    .enablePositionalOptions()
     .argument('[project]', 'Project name to open (supports project:command syntax)')
     .option('-d, --debug', 'Enable debug logging')
     .option('--completion', 'Setup shell tab completion')
@@ -99,12 +100,11 @@ export function createCli(): Command {
           return;
         }
 
-        // If a project name was provided, delegate to the open command
+        // If a project name was provided, delegate to the open command logic
         if (project) {
-          const args = ['open', project];
-          if (options.shell) args.push('--shell');
-          if (options.debug) args.push('--debug');
-          await program.parseAsync(['node', 'workon', ...args]);
+          // Import and call open logic directly instead of re-parsing
+          const { runOpen } = await import('./open.js');
+          await runOpen(project, { debug: options.debug, shell: options.shell }, { config, log });
           return;
         }
 

--- a/src/commands/open.ts
+++ b/src/commands/open.ts
@@ -23,6 +23,23 @@ interface OpenOptions {
   shell?: boolean;
 }
 
+/**
+ * Run the open command logic directly (used when delegating from main CLI)
+ */
+export async function runOpen(
+  projectArg: string,
+  options: OpenOptions,
+  ctx: OpenContext
+): Promise<void> {
+  const { log } = ctx;
+
+  if (options.debug) {
+    log.setLogLevel('debug');
+  }
+
+  await processProject(projectArg, options, ctx);
+}
+
 export function createOpenCommand(ctx: OpenContext): Command {
   const { config, log } = ctx;
 
@@ -235,12 +252,31 @@ async function handleTmuxLayout(
 
   if (isShellMode) {
     if (await tmux.isTmuxAvailable()) {
+      // Process remaining events (like IDE) FIRST, before any tmux commands
+      // This prevents backgrounded commands from interfering with tmux -CC control mode
+      const remainingEvents = events.filter((e) => !layout.handledEvents.includes(e));
+      for (const event of remainingEvents) {
+        const eventHandler = EventRegistry.getEventByName(event);
+        if (eventHandler) {
+          const cmds = eventHandler.processing.generateShellCommand({
+            project,
+            isShellMode: true,
+            shellCommands: [],
+          });
+          shellCommands.push(...cmds);
+        }
+      }
+
+      // Now add all tmux commands (create session, split panes, attach)
       const commands = buildLayoutShellCommands(tmux, project, layout);
       shellCommands.push(...commands);
       tmuxHandled = true;
     } else {
       log.debug('Tmux not available, falling back to normal mode');
-      buildFallbackCommands(shellCommands, project, layout);
+      // Process remaining non-blocking events (like IDE) BEFORE npm in fallback mode
+      // This ensures IDE opens before npm blocks
+      const remainingEvents = events.filter((e) => !layout.handledEvents.includes(e));
+      buildFallbackCommandsWithEvents(shellCommands, project, layout, remainingEvents, ctx);
       tmuxHandled = true;
     }
   } else if (!dryRun) {
@@ -268,7 +304,8 @@ async function handleTmuxLayout(
   }
 
   // Process other events not handled by the layout
-  if (!dryRun) {
+  // Skip in shell mode (events already handled inline above)
+  if (!dryRun && !isShellMode) {
     for (const event of events.filter((e) => !layout.handledEvents.includes(e))) {
       await processEvent(event, { project, isShellMode, shellCommands }, ctx);
     }
@@ -295,22 +332,33 @@ function buildLayoutShellCommands(
   }
 }
 
-function buildFallbackCommands(
+function buildFallbackCommandsWithEvents(
   shellCommands: string[],
   project: Project,
-  layout: LayoutConfig
+  layout: LayoutConfig,
+  remainingEvents: string[],
+  _ctx: OpenContext
 ): void {
-  shellCommands.push(`cd "${project.path.path}"`);
+  // Warn user that tmux is not available
+  shellCommands.push(`echo "⚠ tmux not available - install with: brew install tmux" >&2`);
 
-  if (layout.type === 'split-claude' || layout.type === 'three-pane') {
-    const claudeCommand =
-      layout.claudeArgs.length > 0 ? `claude ${layout.claudeArgs.join(' ')}` : 'claude';
-    shellCommands.push(claudeCommand);
+  // Use pushd so user can popd to go back
+  shellCommands.push(`pushd "${project.path.path}" > /dev/null`);
+
+  // Add non-blocking remaining events (like IDE)
+  for (const event of remainingEvents) {
+    const eventHandler = EventRegistry.getEventByName(event);
+    if (eventHandler) {
+      const cmds = eventHandler.processing.generateShellCommand({
+        project,
+        isShellMode: true,
+        shellCommands: [],
+      });
+      shellCommands.push(...cmds);
+    }
   }
 
-  if (layout.npmCommand) {
-    shellCommands.push(layout.npmCommand);
-  }
+  // Skip blocking commands (npm, claude) - they require tmux for proper UX
 }
 
 async function createTmuxSession(

--- a/src/events/core/cwd.ts
+++ b/src/events/core/cwd.ts
@@ -49,19 +49,26 @@ export class CwdEvent {
         const projectPath = project.path.path;
 
         if (isShellMode) {
-          shellCommands.push(`cd "${projectPath}"`);
+          // Use pushd so user can popd to go back
+          shellCommands.push(`pushd "${projectPath}" > /dev/null`);
         } else {
-          // Spawn a new shell in the project directory
+          // Spawn a new interactive shell in the project directory and wait for it
           const shell = process.env.SHELL || '/bin/bash';
-          spawn(shell, [], {
+          const child = spawn(shell, ['-i'], {
             cwd: projectPath,
             stdio: 'inherit',
+          });
+
+          // Wait for the shell to exit
+          await new Promise<void>((resolve, reject) => {
+            child.on('close', () => resolve());
+            child.on('error', (err) => reject(err));
           });
         }
       },
       generateShellCommand(context: EventProcessingContext): string[] {
         const projectPath = context.project.path.path;
-        return [`cd "${projectPath}"`];
+        return [`pushd "${projectPath}" > /dev/null`];
       },
     };
   }

--- a/src/events/core/ide.ts
+++ b/src/events/core/ide.ts
@@ -50,7 +50,9 @@ export class IdeEvent {
         const ide = project.ide || 'code';
 
         if (isShellMode) {
-          shellCommands.push(`${ide} "${projectPath}" &`);
+          // Disable job monitoring to suppress [n] pid and done messages
+          // that interfere with tmux -CC control mode
+          shellCommands.push(`set +m; ${ide} "${projectPath}" &>/dev/null &`);
         } else {
           spawn(ide, [projectPath], {
             detached: true,
@@ -61,7 +63,9 @@ export class IdeEvent {
       generateShellCommand(context: EventProcessingContext): string[] {
         const projectPath = context.project.path.path;
         const ide = context.project.ide || 'code';
-        return [`${ide} "${projectPath}" &`];
+        // Disable job monitoring to suppress [n] pid and done messages
+        // that interfere with tmux -CC control mode
+        return [`set +m; ${ide} "${projectPath}" &>/dev/null &`];
       },
     };
   }

--- a/src/types/constants.ts
+++ b/src/types/constants.ts
@@ -5,6 +5,7 @@ import type { IdeType } from './index.js';
  * Shared between interactive.ts and manage.ts.
  */
 export const IDE_CHOICES = [
+  { name: 'Cursor', value: 'cursor' as IdeType },
   { name: 'Visual Studio Code', value: 'vscode' as IdeType },
   { name: 'Visual Studio Code (code)', value: 'code' as IdeType },
   { name: 'IntelliJ IDEA', value: 'idea' as IdeType },

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,6 +1,6 @@
 // Project configuration types
 
-export type IdeType = 'vscode' | 'idea' | 'atom' | 'code' | 'subl' | 'vim' | 'emacs';
+export type IdeType = 'vscode' | 'idea' | 'atom' | 'code' | 'subl' | 'vim' | 'emacs' | 'cursor';
 
 export interface ClaudeConfig {
   flags?: string[];

--- a/tests/commands/interactive.test.ts
+++ b/tests/commands/interactive.test.ts
@@ -28,7 +28,15 @@ vi.mock('../../src/lib/tmux.js', () => ({
 
 // Mock child_process to avoid actual spawns
 vi.mock('child_process', () => ({
-  spawn: vi.fn(() => ({ unref: vi.fn() })),
+  spawn: vi.fn(() => ({
+    unref: vi.fn(),
+    on: vi.fn((event: string, callback: () => void) => {
+      // Immediately call close callback to simulate shell exit
+      if (event === 'close') {
+        setTimeout(() => callback(), 0);
+      }
+    }),
+  })),
 }));
 
 // Import after mocking
@@ -242,6 +250,15 @@ describe('switch-project flow', () => {
 
   beforeEach(() => {
     config = new Config();
+    // Clear all existing projects for clean test state
+    const existingProjects = Object.keys(config.getProjects());
+    existingProjects.forEach((name) => {
+      try {
+        config.deleteProject(name);
+      } catch {
+        // Ignore errors
+      }
+    });
     mockLog = {
       debug: vi.fn(),
       info: vi.fn(),

--- a/tests/commands/open.test.ts
+++ b/tests/commands/open.test.ts
@@ -437,6 +437,6 @@ describe('shell mode', () => {
     // Should have output shell commands
     expect(consoleSpy).toHaveBeenCalled();
     const output = consoleSpy.mock.calls.map((c) => c[0]).join('\n');
-    expect(output).toContain('cd');
+    expect(output).toContain('pushd');
   });
 });

--- a/tests/events/core/cwd.test.ts
+++ b/tests/events/core/cwd.test.ts
@@ -74,7 +74,7 @@ describe('CwdEvent', () => {
   });
 
   describe('processing', () => {
-    it('should generate cd shell command', () => {
+    it('should generate pushd shell command', () => {
       const mockProject = {
         path: { path: '/path/to/project' },
         events: { cwd: true },
@@ -87,7 +87,7 @@ describe('CwdEvent', () => {
       } as unknown as Parameters<typeof CwdEvent.processing.generateShellCommand>[0];
 
       const commands = CwdEvent.processing.generateShellCommand(context);
-      expect(commands).toEqual(['cd "/path/to/project"']);
+      expect(commands).toEqual(['pushd "/path/to/project" > /dev/null']);
     });
 
     it('should handle paths with spaces', () => {
@@ -103,7 +103,7 @@ describe('CwdEvent', () => {
       } as unknown as Parameters<typeof CwdEvent.processing.generateShellCommand>[0];
 
       const commands = CwdEvent.processing.generateShellCommand(context);
-      expect(commands).toEqual(['cd "/path/with spaces/project"']);
+      expect(commands).toEqual(['pushd "/path/with spaces/project" > /dev/null']);
     });
   });
 

--- a/tests/events/core/ide.test.ts
+++ b/tests/events/core/ide.test.ts
@@ -82,7 +82,8 @@ describe('IdeEvent', () => {
       } as unknown as Parameters<typeof IdeEvent.processing.generateShellCommand>[0];
 
       const commands = IdeEvent.processing.generateShellCommand(context);
-      expect(commands).toEqual(['code "/path/to/project" &']);
+      // Disable job monitoring to suppress job control output for tmux -CC compatibility
+      expect(commands).toEqual(['set +m; code "/path/to/project" &>/dev/null &']);
     });
 
     it('should use configured ide', () => {
@@ -99,7 +100,7 @@ describe('IdeEvent', () => {
       } as unknown as Parameters<typeof IdeEvent.processing.generateShellCommand>[0];
 
       const commands = IdeEvent.processing.generateShellCommand(context);
-      expect(commands).toEqual(['idea "/path/to/project" &']);
+      expect(commands).toEqual(['set +m; idea "/path/to/project" &>/dev/null &']);
     });
 
     it('should handle paths with spaces', () => {
@@ -115,7 +116,7 @@ describe('IdeEvent', () => {
       } as unknown as Parameters<typeof IdeEvent.processing.generateShellCommand>[0];
 
       const commands = IdeEvent.processing.generateShellCommand(context);
-      expect(commands).toEqual(['code "/path/with spaces/project" &']);
+      expect(commands).toEqual(['set +m; code "/path/with spaces/project" &>/dev/null &']);
     });
   });
 


### PR DESCRIPTION
## Summary
- Fix IDE command interfering with tmux -CC by using `set +m` to disable job monitoring
- Fix --shell option not passing correctly by calling runOpen directly
- Use pushd instead of cd for directory changes (allows popd to return)
- Process IDE command before tmux attach to prevent interference with control mode
- Add fallback warning when tmux is not available
- Add Cursor IDE support with auto-detection of .cursor directory
- Auto-detect CLAUDE.md to enable claude event on project add

## Test plan
- [x] All 382 tests passing
- [x] Type-check clean
- [x] Lint clean
- [x] Manual testing of `workon <project>` with tmux -CC in iTerm2
- [x] Verified 2-pane and 3-pane layouts work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)