### PR TITLE
fix: return to shell when tmux pane process exits

### DIFF
--- a/src/lib/tmux.ts
+++ b/src/lib/tmux.ts
@@ -9,8 +9,10 @@ const exec = promisify(execCallback);
  * This prevents tmux panes from showing "Pane is dead" after a process ends.
  */
 function wrapWithShellFallback(command: string): string {
-  // Use $SHELL to get the user's preferred shell, with /bin/sh as fallback
-  return `${command}; exec \${SHELL:-/bin/sh}`;
+  // Use $SHELL to get the user's preferred shell.
+  // Note: We use simple $SHELL syntax (not ${SHELL:-default}) for compatibility
+  // with non-POSIX shells like fish and csh that tmux may use to execute commands.
+  return `${command}; exec $SHELL`;
 }
 
 export class TmuxManager {

--- a/tests/lib/tmux.test.ts
+++ b/tests/lib/tmux.test.ts
@@ -38,7 +38,7 @@ describe('TmuxManager', () => {
         "tmux has-session -t 'workon-myproject' 2>/dev/null && tmux kill-session -t 'workon-myproject'"
       );
       expect(commands).toContain(
-        "tmux new-session -d -s 'workon-myproject' -c '/path/to/project' 'claude; exec ${SHELL:-/bin/sh}'"
+        "tmux new-session -d -s 'workon-myproject' -c '/path/to/project' 'claude; exec $SHELL'"
       );
       expect(commands).toContain(
         "tmux split-window -h -t 'workon-myproject' -c '/path/to/project'"
@@ -53,7 +53,7 @@ describe('TmuxManager', () => {
       ]);
 
       expect(commands).toContain(
-        "tmux new-session -d -s 'workon-myproject' -c '/path/to/project' 'claude --model opus; exec ${SHELL:-/bin/sh}'"
+        "tmux new-session -d -s 'workon-myproject' -c '/path/to/project' 'claude --model opus; exec $SHELL'"
       );
     });
 
@@ -81,7 +81,7 @@ describe('TmuxManager', () => {
 
       expect(commands).toContain('# Create tmux three-pane session for myproject');
       expect(commands).toContain(
-        "tmux split-window -v -t 'workon-myproject:0.1' -c '/path/to/project' 'npm run dev; exec ${SHELL:-/bin/sh}'"
+        "tmux split-window -v -t 'workon-myproject:0.1' -c '/path/to/project' 'npm run dev; exec $SHELL'"
       );
       expect(commands).toContain("tmux resize-pane -t 'workon-myproject:0.2' -y 10");
     });
@@ -94,7 +94,7 @@ describe('TmuxManager', () => {
         'pnpm run start'
       );
 
-      expect(commands.some((c) => c.includes('pnpm run start; exec ${SHELL:-/bin/sh}'))).toBe(true);
+      expect(commands.some((c) => c.includes('pnpm run start; exec $SHELL'))).toBe(true);
     });
 
     it('should include claude flags', () => {
@@ -103,7 +103,7 @@ describe('TmuxManager', () => {
       ]);
 
       expect(commands).toContain(
-        "tmux new-session -d -s 'workon-myproject' -c '/path/to/project' 'claude --resume; exec ${SHELL:-/bin/sh}'"
+        "tmux new-session -d -s 'workon-myproject' -c '/path/to/project' 'claude --resume; exec $SHELL'"
       );
     });
   });
@@ -117,7 +117,7 @@ describe('TmuxManager', () => {
         "tmux new-session -d -s 'workon-myproject' -c '/path/to/project'"
       );
       expect(commands).toContain(
-        "tmux split-window -h -t 'workon-myproject' -c '/path/to/project' 'npm run dev; exec ${SHELL:-/bin/sh}'"
+        "tmux split-window -h -t 'workon-myproject' -c '/path/to/project' 'npm run dev; exec $SHELL'"
       );
     });
 
@@ -128,7 +128,7 @@ describe('TmuxManager', () => {
         'yarn start'
       );
 
-      expect(commands.some((c) => c.includes('yarn start; exec ${SHELL:-/bin/sh}'))).toBe(true);
+      expect(commands.some((c) => c.includes('yarn start; exec $SHELL'))).toBe(true);
     });
   });
 


### PR DESCRIPTION
## Summary
- When a process (like `claude` or an npm script) exits in a tmux pane, the pane now returns to a shell instead of showing "Pane is dead"
- Added shell fallback wrapper that appends `; exec ${SHELL:-/bin/sh}` to commands run in tmux panes
- Removed the now-unnecessary `remain-on-exit` tmux option

## Test plan
- [x] Open a project with tmux integration (`workon <project>`)
- [x] Exit Claude (e.g., type `/exit` or Ctrl+C)
- [x] Verify the pane drops to a shell prompt instead of showing "Pane is dead"
- [x] Test with npm pane as well (Ctrl+C to stop dev server)

🤖 Generated with [Claude Code](https://claude.ai/code)