### PR TITLE
feat: harden worktree lifecycle and reuse existing tmux sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,8 +192,12 @@ workon worktrees list
 # Create a new worktree
 workon worktrees add feature-branch
 
-# Open workon session in a worktree (creates tmux session)
+# Open workon session in a worktree (creates tmux session, or attaches
+# to the existing one so a running session is never torn down)
 workon worktrees open feature-branch
+
+# Rebuild the session from scratch instead of attaching
+workon worktrees open feature-branch --recreate
 
 # Remove a worktree
 workon worktrees remove feature-branch
@@ -210,7 +214,7 @@ workon worktrees branch my-worktree new-branch-name --push
 When you're inside a worktree, use `workon worktree` (singular):
 
 ```bash
-cd ~/code/myproject/.worktrees/feature-branch
+cd ~/.workon/worktrees/myproject-a1b2c3d4/feature-branch
 
 # Show status of current worktree
 workon worktree
@@ -220,6 +224,8 @@ workon worktree status
 workon worktree merge
 
 # Recycle worktree for the next task (ff to latest main)
+# Always returns to the worktree's own branch first, even if the last task
+# left another branch checked out - recreating that branch if it was deleted
 workon worktree recycle
 
 # Remove this worktree (shows instructions to exit first)
@@ -231,10 +237,12 @@ If you run `workon worktrees` from inside a worktree, you'll get a helpful error
 #### Notes
 
 - If you run worktree commands from an unregistered git repository, workon will prompt you to register it first
-- Worktrees created by workon are stored in `.worktrees/` inside the project
-- External worktrees (created elsewhere) show as "(external)" in the list
+- Worktrees created by workon are stored in `~/.workon/worktrees/{project}-{hash}/`, keeping the project directory clean
+- External worktrees (created elsewhere) show as "(external)" in the list; removing one deletes its directory, so workon warns first
+- `merge` runs in the main repository: it requires a clean main worktree and puts it back on the branch it was on when it finishes
+- A merge that conflicts is rolled back - the worktree and its branch are left untouched so nothing is lost
 
-#### Post-Setup Hook
+#### Setup and Teardown Hooks
 
 Create `.workon/worktree-setup.sh` in your project to run commands after creating a worktree:
 
@@ -247,9 +255,17 @@ Create `.workon/worktree-setup.sh` in your project to run commands after creatin
 [ -f "$PROJECT_PATH/.env" ] && cp "$PROJECT_PATH/.env" .env
 ```
 
+Create `.workon/worktree-teardown.sh` to run commands before a worktree is removed
+(stop containers, free ports, archive logs).
+
 Environment variables available:
-- `WORKTREE_PATH` - Absolute path to the new worktree
+- `WORKTREE_PATH` - Absolute path to the worktree
 - `PROJECT_PATH` - Absolute path to the main project
+- `WORKTREE_NAME` - Directory name of the worktree
+
+Hooks run with the worktree as the working directory and are given 15 minutes to
+finish; set `WORKON_HOOK_TIMEOUT` (milliseconds) to change that. Skip them for a
+single command with `--no-hook`.
 
 ### Legacy Mode (Nested Shells)
 ```bash

--- a/src/commands/worktree.ts
+++ b/src/commands/worktree.ts
@@ -312,6 +312,11 @@ async function mergeCurrentWorktree(
     mergeSpinner.succeed(`Successfully merged '${worktreeInfo.branch}' into '${targetBranch}'`);
     if (result.restored && result.previousBranch) {
       log.debug(`Main worktree restored to '${result.previousBranch}'`);
+    } else if (result.previousBranch && result.previousBranch !== targetBranch) {
+      log.warn(
+        `Merged, but could not switch the main worktree back to ` +
+          `'${result.previousBranch}'; it is left on '${targetBranch}'.`
+      );
     }
   } catch (error) {
     mergeSpinner.fail(`Merge failed: ${(error as Error).message}`);

--- a/src/commands/worktree.ts
+++ b/src/commands/worktree.ts
@@ -1,17 +1,78 @@
 import { Command } from 'commander';
 import chalk from 'chalk';
 import ora from 'ora';
+import path from 'path';
+import { existsSync } from 'fs';
 import { select, confirm } from '@inquirer/prompts';
 import { simpleGit } from 'simple-git';
 import type { Config } from '../lib/config.js';
 import type { Logger } from '../types/index.js';
-import { WorktreeManager } from '../lib/worktree.js';
+import { WorktreeManager, gitProbe, type WorktreeBranchInfo } from '../lib/worktree.js';
 import { TmuxManager } from '../lib/tmux.js';
-import { detectWorktreeContext, type WorktreeInfo } from './worktrees/utils.js';
+import { resolveProjectFromCwd, type WorktreeInfo } from './worktrees/utils.js';
 
 interface WorktreeContext {
   config: Config;
   log: Logger;
+}
+
+interface ResolvedWorktree {
+  info: WorktreeInfo & { worktreePath: string; worktreeName: string };
+  /** Name used to build the tmux session; must match `workon worktrees open` */
+  displayName: string;
+}
+
+/**
+ * Resolve the worktree we're standing in, or exit with a useful message.
+ *
+ * Goes through resolveProjectFromCwd rather than detectWorktreeContext so we
+ * pick up the *registered* project name: `workon worktrees open` derives tmux
+ * session names from it, and deriving them from the directory basename here
+ * meant we killed a session that didn't exist while the real one lived on.
+ */
+async function requireWorktree(ctx: WorktreeContext, hint?: string): Promise<ResolvedWorktree> {
+  const { config, log } = ctx;
+  const projectCtx = await resolveProjectFromCwd(config, log);
+
+  if (!projectCtx) {
+    log.error('Not in a git repository.');
+    process.exit(1);
+  }
+
+  const info = projectCtx.worktreeInfo;
+
+  if (!info.isWorktree) {
+    log.error("You're in the main repository, not a worktree.");
+    if (hint) {
+      log.info(hint);
+    }
+    process.exit(1);
+  }
+
+  if (!info.worktreePath || !info.worktreeName) {
+    log.error('Unable to determine worktree info.');
+    process.exit(1);
+  }
+
+  if (!existsSync(info.worktreePath)) {
+    log.error(`Worktree directory is missing from disk: ${info.worktreePath}`);
+    process.exit(1);
+  }
+
+  return {
+    info: info as ResolvedWorktree['info'],
+    displayName: projectCtx.projectName || path.basename(info.mainRepoPath),
+  };
+}
+
+/**
+ * Uncommitted-changes check that talks to the worktree directly.
+ * WorktreeManager.hasUncommittedChanges throws when the name can't be resolved,
+ * which surfaced as an unhandled rejection from inside a worktree.
+ */
+async function worktreeHasChanges(worktreePath: string): Promise<boolean> {
+  const status = await simpleGit(worktreePath).status();
+  return !status.isClean();
 }
 
 /**
@@ -26,20 +87,11 @@ export function createWorktreeCommand(ctx: WorktreeContext): Command {
 
   // Default action: show worktree status
   command.action(async () => {
-    const worktreeInfo = await detectWorktreeContext();
-
-    if (!worktreeInfo) {
-      log.error('Not in a git repository.');
-      process.exit(1);
-    }
-
-    if (!worktreeInfo.isWorktree) {
-      log.error("You're in the main repository, not a worktree.");
-      log.info(`Use 'workon worktrees' to manage worktrees for this project.`);
-      process.exit(1);
-    }
-
-    await showWorktreeStatus(worktreeInfo, log);
+    const { info } = await requireWorktree(
+      ctx,
+      `Use 'workon worktrees' to manage worktrees for this project.`
+    );
+    await showWorktreeStatus(info, log);
   });
 
   // Subcommand: status
@@ -47,19 +99,8 @@ export function createWorktreeCommand(ctx: WorktreeContext): Command {
     .command('status')
     .description('Show status of the current worktree')
     .action(async () => {
-      const worktreeInfo = await detectWorktreeContext();
-
-      if (!worktreeInfo) {
-        log.error('Not in a git repository.');
-        process.exit(1);
-      }
-
-      if (!worktreeInfo.isWorktree) {
-        log.error("You're in the main repository, not a worktree.");
-        process.exit(1);
-      }
-
-      await showWorktreeStatus(worktreeInfo, log);
+      const { info } = await requireWorktree(ctx);
+      await showWorktreeStatus(info, log);
     });
 
   // Subcommand: merge
@@ -79,20 +120,11 @@ export function createWorktreeCommand(ctx: WorktreeContext): Command {
         yes?: boolean;
         deleteBranch?: boolean;
       }) => {
-        const worktreeInfo = await detectWorktreeContext();
-
-        if (!worktreeInfo) {
-          log.error('Not in a git repository.');
-          process.exit(1);
-        }
-
-        if (!worktreeInfo.isWorktree) {
-          log.error("You're in the main repository, not a worktree.");
-          log.info(`Use 'workon worktrees merge <name>' from the main repository.`);
-          process.exit(1);
-        }
-
-        await mergeCurrentWorktree(worktreeInfo, options, ctx);
+        const resolved = await requireWorktree(
+          ctx,
+          `Use 'workon worktrees merge <name>' from the main repository.`
+        );
+        await mergeCurrentWorktree(resolved, options, ctx);
       }
     );
 
@@ -103,20 +135,11 @@ export function createWorktreeCommand(ctx: WorktreeContext): Command {
     .option('-f, --force', 'Force removal even with uncommitted changes')
     .option('-y, --yes', 'Skip confirmation prompt')
     .action(async (options: { force?: boolean; yes?: boolean }) => {
-      const worktreeInfo = await detectWorktreeContext();
-
-      if (!worktreeInfo) {
-        log.error('Not in a git repository.');
-        process.exit(1);
-      }
-
-      if (!worktreeInfo.isWorktree) {
-        log.error("You're in the main repository, not a worktree.");
-        log.info(`Use 'workon worktrees remove <name>' from the main repository.`);
-        process.exit(1);
-      }
-
-      await removeCurrentWorktree(worktreeInfo, options, ctx);
+      const resolved = await requireWorktree(
+        ctx,
+        `Use 'workon worktrees remove <name>' from the main repository.`
+      );
+      await removeCurrentWorktree(resolved, options, ctx);
     });
 
   // Subcommand: recycle
@@ -128,19 +151,8 @@ export function createWorktreeCommand(ctx: WorktreeContext): Command {
     .argument('[branch]', 'Remote branch to fast-forward to (auto-detects default)')
     .option('-y, --yes', 'Skip confirmation prompt')
     .action(async (branch: string | undefined, options: { yes?: boolean }) => {
-      const worktreeInfo = await detectWorktreeContext();
-
-      if (!worktreeInfo) {
-        log.error('Not in a git repository.');
-        process.exit(1);
-      }
-
-      if (!worktreeInfo.isWorktree) {
-        log.error("You're in the main repository, not a worktree.");
-        process.exit(1);
-      }
-
-      await recycleCurrentWorktree(worktreeInfo, branch, options, ctx);
+      const resolved = await requireWorktree(ctx);
+      await recycleCurrentWorktree(resolved, branch, options, ctx);
     });
 
   return command;
@@ -154,13 +166,10 @@ async function showWorktreeStatus(worktreeInfo: WorktreeInfo, log: Logger): Prom
 
   const git = simpleGit(worktreeInfo.worktreePath);
 
-  // Get git status
+  // Get git status. isClean() also covers conflicted and renamed entries, which
+  // an explicit list of buckets kept missing.
   const status = await git.status();
-  const hasChanges =
-    status.modified.length > 0 ||
-    status.not_added.length > 0 ||
-    status.deleted.length > 0 ||
-    status.staged.length > 0;
+  const hasChanges = !status.isClean();
 
   console.log(chalk.bold('\nCurrent Worktree:'));
   console.log('-'.repeat(50));
@@ -188,6 +197,9 @@ async function showWorktreeStatus(worktreeInfo: WorktreeInfo, log: Logger): Prom
     if (status.deleted.length > 0) {
       console.log(`  Deleted:  ${status.deleted.length} file(s)`);
     }
+    if (status.conflicted.length > 0) {
+      console.log(`  Conflicted: ${status.conflicted.length} file(s)`);
+    }
   }
 
   console.log(`\n${chalk.bold('Commands:')}`);
@@ -198,7 +210,7 @@ async function showWorktreeStatus(worktreeInfo: WorktreeInfo, log: Logger): Prom
 }
 
 async function mergeCurrentWorktree(
-  worktreeInfo: WorktreeInfo,
+  resolved: ResolvedWorktree,
   options: {
     into?: string;
     squash?: boolean;
@@ -209,11 +221,7 @@ async function mergeCurrentWorktree(
   ctx: WorktreeContext
 ): Promise<void> {
   const { log } = ctx;
-
-  if (!worktreeInfo.worktreePath || !worktreeInfo.worktreeName) {
-    log.error('Unable to determine worktree info.');
-    process.exit(1);
-  }
+  const { info: worktreeInfo, displayName } = resolved;
 
   if (worktreeInfo.branch === '(detached)') {
     log.error('Cannot merge a detached HEAD. Create a branch first.');
@@ -224,7 +232,7 @@ async function mergeCurrentWorktree(
   const manager = new WorktreeManager(worktreeInfo.mainRepoPath);
 
   // Check for uncommitted changes
-  const hasChanges = await manager.hasUncommittedChanges(worktreeInfo.worktreeName);
+  const hasChanges = await worktreeHasChanges(worktreeInfo.worktreePath);
   if (hasChanges) {
     log.error('This worktree has uncommitted changes.');
     log.info('Please commit or stash your changes before merging.');
@@ -297,14 +305,17 @@ async function mergeCurrentWorktree(
   const mergeSpinner = ora(`Merging '${worktreeInfo.branch}' into '${targetBranch}'...`).start();
 
   try {
-    await manager.merge(worktreeInfo.worktreeName, {
+    const result = await manager.merge(worktreeInfo.worktreeName, {
       targetBranch,
       squash: squash || false,
     });
     mergeSpinner.succeed(`Successfully merged '${worktreeInfo.branch}' into '${targetBranch}'`);
+    if (result.restored && result.previousBranch) {
+      log.debug(`Main worktree restored to '${result.previousBranch}'`);
+    }
   } catch (error) {
     mergeSpinner.fail(`Merge failed: ${(error as Error).message}`);
-    log.info('You may need to resolve conflicts manually.');
+    log.info('Nothing was merged or removed; the worktree and its branch are untouched.');
     process.exit(1);
   }
 
@@ -329,10 +340,7 @@ async function mergeCurrentWorktree(
     if (shouldContinue) {
       // Kill any associated tmux session
       const tmux = new TmuxManager();
-      const sessionName = tmux.getWorktreeSessionName(
-        worktreeInfo.mainRepoPath.split('/').pop() || 'project',
-        worktreeInfo.worktreeName
-      );
+      const sessionName = tmux.getWorktreeSessionName(displayName, worktreeInfo.worktreeName);
       if (await tmux.sessionExists(sessionName)) {
         log.debug(`Killing tmux session: ${sessionName}`);
         await tmux.killSession(sessionName);
@@ -368,21 +376,15 @@ async function mergeCurrentWorktree(
 }
 
 async function removeCurrentWorktree(
-  worktreeInfo: WorktreeInfo,
+  resolved: ResolvedWorktree,
   options: { force?: boolean; yes?: boolean },
   ctx: WorktreeContext
 ): Promise<void> {
   const { log } = ctx;
-
-  if (!worktreeInfo.worktreePath || !worktreeInfo.worktreeName) {
-    log.error('Unable to determine worktree info.');
-    process.exit(1);
-  }
-
-  const manager = new WorktreeManager(worktreeInfo.mainRepoPath);
+  const { info: worktreeInfo } = resolved;
 
   // Check for uncommitted changes
-  const hasChanges = await manager.hasUncommittedChanges(worktreeInfo.worktreeName);
+  const hasChanges = await worktreeHasChanges(worktreeInfo.worktreePath);
   if (hasChanges && !options.force) {
     log.warn('This worktree has uncommitted changes.');
 
@@ -437,37 +439,34 @@ async function removeCurrentWorktree(
 /**
  * Resolve the original branch a worktree was created for.
  *
- * We cannot rely on the `branch` field from `git worktree list --porcelain`
- * because that reflects the *currently checked-out* branch, which may have
- * changed (e.g., after `worktrees branch feat-x pr-branch`).
- *
- * Instead, we use the WorktreeManager which created the worktree: worktree
- * names are derived from branches via `branchToDir()` (slashes → hyphens).
- * We look up the worktree by name and get its original branch from the
- * manager's data, which cross-references the worktree path against
- * `git worktree list` and the managed worktrees directory.
+ * `git worktree list --porcelain` reports the *currently* checked-out branch,
+ * which may have moved on (e.g. after `worktrees branch feat-x pr-branch`), so
+ * the manager maps the worktree's directory name back to a local branch.
  */
 async function getWorktreeOriginalBranch(
   mainRepoPath: string,
   worktreeName: string
-): Promise<string | null> {
+): Promise<WorktreeBranchInfo | null> {
   try {
     const manager = new WorktreeManager(mainRepoPath);
-    const worktree = await manager.get(worktreeName);
-    if (worktree && worktree.branch && worktree.branch !== '(detached)') {
-      return worktree.branch;
-    }
+    return await manager.getOriginalBranch(worktreeName);
+  } catch {
+    return null;
+  }
+}
 
-    // Fallback: check all local branches for one whose branchToDir form
-    // matches the worktree name (handles external worktrees)
-    const git = simpleGit(mainRepoPath);
-    const branches = await git.branchLocal();
-    for (const branchName of branches.all) {
-      if (branchName.replace(/\//g, '-') === worktreeName) {
-        return branchName;
-      }
-    }
-
+/**
+ * Pick the remote to recycle against: `origin` when it exists, otherwise the
+ * only configured remote. Ambiguity is reported rather than guessed.
+ *
+ * Exported for testing.
+ */
+export async function resolveRemote(git: ReturnType<typeof simpleGit>): Promise<string | null> {
+  try {
+    const remotes = await git.getRemotes(false);
+    const names = remotes.map((r) => r.name);
+    if (names.includes('origin')) return 'origin';
+    if (names.length === 1) return names[0];
     return null;
   } catch {
     return null;
@@ -475,15 +474,50 @@ async function getWorktreeOriginalBranch(
 }
 
 /**
- * Detect the default remote branch (main, master, develop, dev) by checking
- * which ones exist as remote tracking branches.
+ * Detect the remote's default branch.
+ *
+ * Tries local refs first (`origin/HEAD`, then well-known names) so the command
+ * still works offline, and only falls back to `ls-remote` when the repository
+ * has no local knowledge of the remote.
  */
-async function detectDefaultRemoteBranch(
-  git: ReturnType<typeof simpleGit>
+export async function detectDefaultRemoteBranch(
+  git: ReturnType<typeof simpleGit>,
+  remote: string
 ): Promise<string | null> {
   const candidates = ['main', 'master', 'develop', 'dev'];
+
+  // Note: these probes go through gitProbe rather than try/catch. `--quiet` git
+  // commands exit non-zero *silently*, and simple-git only reports a command as
+  // failed when it writes to stderr - so catching a throw here would never fire
+  // and every repository would look like it had the first candidate.
+
+  // 1. Whatever the remote itself says its HEAD is.
+  const head = await gitProbe(git, [
+    'symbolic-ref',
+    '--quiet',
+    '--short',
+    `refs/remotes/${remote}/HEAD`,
+  ]);
+  if (head && head.startsWith(`${remote}/`)) {
+    return head.substring(remote.length + 1);
+  }
+
+  // 2. Known-good names that already exist as remote-tracking refs.
+  for (const candidate of candidates) {
+    const ref = await gitProbe(git, [
+      'rev-parse',
+      '--verify',
+      '--quiet',
+      `refs/remotes/${remote}/${candidate}`,
+    ]);
+    if (ref) {
+      return candidate;
+    }
+  }
+
+  // 3. Last resort: ask the remote (requires network).
   try {
-    const remoteRefs = await git.raw(['ls-remote', '--heads', 'origin']);
+    const remoteRefs = await git.raw(['ls-remote', '--heads', remote]);
     // Parse each line and extract exact ref names to avoid prefix matching
     // (e.g., "refs/heads/mainline" should not match "main")
     const refNames = new Set(
@@ -505,17 +539,13 @@ async function detectDefaultRemoteBranch(
 }
 
 async function recycleCurrentWorktree(
-  worktreeInfo: WorktreeInfo,
+  resolved: ResolvedWorktree,
   targetBranch: string | undefined,
   options: { yes?: boolean },
   ctx: WorktreeContext
 ): Promise<void> {
   const { log } = ctx;
-
-  if (!worktreeInfo.worktreePath || !worktreeInfo.worktreeName) {
-    log.error('Unable to determine worktree info.');
-    process.exit(1);
-  }
+  const { info: worktreeInfo } = resolved;
 
   if (worktreeInfo.branch === '(detached)') {
     log.error('Worktree is in detached HEAD state.');
@@ -525,20 +555,28 @@ async function recycleCurrentWorktree(
 
   const git = simpleGit(worktreeInfo.worktreePath);
 
+  const remote = await resolveRemote(git);
+  if (!remote) {
+    log.error('No usable git remote found (expected `origin`, or exactly one remote).');
+    process.exit(1);
+  }
+
   // Resolve the worktree's original branch (the branch it was created for, not the current checkout)
-  const originalBranch = await getWorktreeOriginalBranch(
+  const original = await getWorktreeOriginalBranch(
     worktreeInfo.mainRepoPath,
     worktreeInfo.worktreeName
   );
 
-  if (!originalBranch) {
+  if (!original) {
     log.error('Unable to determine the branch associated with this worktree.');
     process.exit(1);
   }
 
+  const originalBranch = original.branch;
+
   // Resolve target branch: use provided value, or detect the repo's default branch
   if (!targetBranch) {
-    const detected = await detectDefaultRemoteBranch(git);
+    const detected = await detectDefaultRemoteBranch(git, remote);
     if (!detected) {
       log.error('Could not detect default remote branch (tried main, master, develop, dev).');
       log.info('Specify the branch explicitly: workon worktree recycle <branch>');
@@ -547,24 +585,15 @@ async function recycleCurrentWorktree(
     targetBranch = detected;
   }
 
-  // Check for uncommitted changes
-  const status = await git.status();
-  const hasChanges =
-    status.modified.length > 0 ||
-    status.not_added.length > 0 ||
-    status.deleted.length > 0 ||
-    status.staged.length > 0 ||
-    status.created.length > 0 ||
-    status.renamed.length > 0 ||
-    status.conflicted.length > 0;
-
-  if (hasChanges) {
+  // Check for uncommitted changes. isClean() also catches conflicted and
+  // renamed entries that an explicit bucket list misses.
+  if (await worktreeHasChanges(worktreeInfo.worktreePath)) {
     log.error('This worktree has uncommitted changes.');
     log.info('Please commit, stash, or discard your changes before recycling.');
     process.exit(1);
   }
 
-  const alreadyOnBranch = worktreeInfo.branch === originalBranch;
+  const alreadyOnBranch = original.exists && worktreeInfo.branch === originalBranch;
 
   // Confirm the operation
   if (!options.yes) {
@@ -572,11 +601,14 @@ async function recycleCurrentWorktree(
     console.log(`  Worktree:  ${chalk.cyan(worktreeInfo.worktreeName)}`);
     if (alreadyOnBranch) {
       console.log(`  Branch:    ${chalk.green(originalBranch)} (already on it)`);
+    } else if (!original.exists) {
+      console.log(`  Current:   ${chalk.yellow(worktreeInfo.branch)}`);
+      console.log(`  Recreate:  ${chalk.green(originalBranch)} (branch no longer exists)`);
     } else {
       console.log(`  Current:   ${chalk.yellow(worktreeInfo.branch)}`);
       console.log(`  Switch to: ${chalk.green(originalBranch)}`);
     }
-    console.log(`  FF from:   ${chalk.green(`origin/${targetBranch}`)}`);
+    console.log(`  FF from:   ${chalk.green(`${remote}/${targetBranch}`)}`);
     console.log();
 
     const shouldProceed = await confirm({
@@ -593,34 +625,63 @@ async function recycleCurrentWorktree(
   const spinner = ora('Fetching latest from remote...').start();
 
   try {
-    // Fetch the target branch from remote
-    await git.fetch('origin', targetBranch);
+    // Fetch the target branch. A failure here (offline, auth) is not fatal as
+    // long as we already have the remote-tracking ref locally - it just means
+    // recycling to whatever we last fetched.
+    try {
+      await git.fetch(remote, targetBranch);
+    } catch (fetchError) {
+      const hasLocalRef = await gitProbe(git, [
+        'rev-parse',
+        '--verify',
+        '--quiet',
+        `refs/remotes/${remote}/${targetBranch}`,
+      ]);
 
-    // Switch to the original branch if not already on it
-    if (!alreadyOnBranch) {
-      spinner.text = `Switching to branch '${originalBranch}'...`;
-      await git.checkout(originalBranch);
+      if (!hasLocalRef) {
+        throw fetchError;
+      }
+      spinner.warn(
+        `Could not fetch from '${remote}'; using the last known ${remote}/${targetBranch}.`
+      );
+      spinner.start();
     }
 
-    spinner.text = `Fast-forwarding '${originalBranch}' to origin/${targetBranch}...`;
+    if (!original.exists) {
+      // The worktree's branch was deleted (usually cleaned up after merging).
+      // Recreate it at the target tip so the worktree still ends up on its own
+      // branch rather than fast-forwarding whatever the last task left behind.
+      // --no-track keeps the new branch from adopting the target as its
+      // upstream, which would make a later `git push` here target that branch.
+      spinner.text = `Recreating branch '${originalBranch}' at ${remote}/${targetBranch}...`;
+      await git.checkout(['--no-track', '-b', originalBranch, `${remote}/${targetBranch}`]);
+    } else {
+      // Switch to the original branch if not already on it
+      if (!alreadyOnBranch) {
+        spinner.text = `Switching to branch '${originalBranch}'...`;
+        await git.checkout(originalBranch);
+      }
 
-    // Fast-forward to the remote branch tip
-    await git.merge([`origin/${targetBranch}`, '--ff-only']);
+      spinner.text = `Fast-forwarding '${originalBranch}' to ${remote}/${targetBranch}...`;
 
-    spinner.succeed(`Recycled! '${originalBranch}' is now at the tip of origin/${targetBranch}`);
+      // Fast-forward to the remote branch tip
+      await git.merge([`${remote}/${targetBranch}`, '--ff-only']);
+    }
+
+    spinner.succeed(`Recycled! '${originalBranch}' is now at the tip of ${remote}/${targetBranch}`);
     console.log(chalk.green('\nWorktree is ready for the next task.'));
   } catch (error) {
     const message = (error as Error).message;
     spinner.fail('Recycle failed.');
 
-    if (message.includes('ff-only')) {
+    if (message.includes('ff-only') || message.includes('Not possible to fast-forward')) {
       log.error(
-        `Cannot fast-forward '${originalBranch}' to origin/${targetBranch}. ` +
+        `Cannot fast-forward '${originalBranch}' to ${remote}/${targetBranch}. ` +
           `The branch has diverged.`
       );
       log.info('You may need to reset or rebase manually.');
-    } else if (message.includes('did not match any')) {
-      log.error(`Remote branch 'origin/${targetBranch}' not found.`);
+    } else if (message.includes('did not match any') || message.includes("couldn't find remote")) {
+      log.error(`Remote branch '${remote}/${targetBranch}' not found.`);
     } else {
       log.error(message);
     }

--- a/src/commands/worktrees/add.ts
+++ b/src/commands/worktrees/add.ts
@@ -85,6 +85,28 @@ export function createAddCommand(ctx: WorktreesContext): Command {
         }
       }
 
+      // A --force replace destroys the existing worktree's directory. Give the
+      // user a chance to bail before it takes uncommitted work with it.
+      if (options.force) {
+        const existing = await manager.get(manager.branchToDir(branch));
+        if (existing && !existing.isMain && (await manager.hasUncommittedChanges(existing.path))) {
+          log.warn(`Worktree '${existing.name}' has uncommitted changes at ${existing.path}.`);
+          if (options.yes) {
+            log.error('Refusing to overwrite it. Commit, stash, or remove it explicitly first.');
+            process.exit(1);
+          }
+          const shouldReplace = await confirm({
+            message: 'Replace it anyway and lose those changes?',
+            default: false,
+          });
+          if (!shouldReplace) {
+            log.info('Cancelled.');
+            return;
+          }
+          await manager.remove(existing.name, true);
+        }
+      }
+
       const spinner = ora(`Creating worktree for branch '${branch}'...`).start();
 
       try {

--- a/src/commands/worktrees/merge.ts
+++ b/src/commands/worktrees/merge.ts
@@ -146,14 +146,17 @@ export function createMergeCommand(ctx: WorktreesContext): Command {
       const mergeSpinner = ora(`Merging '${worktree.branch}' into '${targetBranch}'...`).start();
 
       try {
-        await manager.merge(name, {
+        const result = await manager.merge(name, {
           targetBranch,
           squash: squash || false,
         });
         mergeSpinner.succeed(`Successfully merged '${worktree.branch}' into '${targetBranch}'`);
+        if (result.restored && result.previousBranch) {
+          log.info(`Main worktree left on '${result.previousBranch}', as it was before the merge.`);
+        }
       } catch (error) {
         mergeSpinner.fail(`Merge failed: ${(error as Error).message}`);
-        log.info('You may need to resolve conflicts manually.');
+        log.info('Nothing was merged or removed; the worktree and its branch are untouched.');
         process.exit(1);
       }
 

--- a/src/commands/worktrees/merge.ts
+++ b/src/commands/worktrees/merge.ts
@@ -153,6 +153,11 @@ export function createMergeCommand(ctx: WorktreesContext): Command {
         mergeSpinner.succeed(`Successfully merged '${worktree.branch}' into '${targetBranch}'`);
         if (result.restored && result.previousBranch) {
           log.info(`Main worktree left on '${result.previousBranch}', as it was before the merge.`);
+        } else if (result.previousBranch && result.previousBranch !== targetBranch) {
+          log.warn(
+            `Merged, but could not switch the main worktree back to ` +
+              `'${result.previousBranch}'; it is left on '${targetBranch}'.`
+          );
         }
       } catch (error) {
         mergeSpinner.fail(`Merge failed: ${(error as Error).message}`);

--- a/src/commands/worktrees/open.ts
+++ b/src/commands/worktrees/open.ts
@@ -1,10 +1,11 @@
 import { Command } from 'commander';
 import chalk from 'chalk';
 import path from 'path';
+import { existsSync } from 'fs';
 import type { Config } from '../../lib/config.js';
 import type { Logger, Project } from '../../types/index.js';
 import { WorktreeManager } from '../../lib/worktree.js';
-import { TmuxManager } from '../../lib/tmux.js';
+import { TmuxManager, sessionTarget, paneTarget } from '../../lib/tmux.js';
 import { resolveProjectFromCwd, promptToRegisterProject, type ProjectContext } from './utils.js';
 import { blockIfInWorktree } from './index.js';
 import { Project as ProjectClass } from '../../lib/project.js';
@@ -19,6 +20,7 @@ interface OpenOptions {
   shell?: boolean;
   attach?: boolean; // Default true, set false to create session without attaching
   yes?: boolean;
+  recreate?: boolean; // Tear down and rebuild an existing session
 }
 
 export function createOpenCommand(ctx: WorktreesContext): Command {
@@ -30,6 +32,7 @@ export function createOpenCommand(ctx: WorktreesContext): Command {
     .option('-d, --debug', 'Enable debug logging')
     .option('--shell', 'Output shell commands instead of spawning processes')
     .option('-y, --yes', 'Skip all confirmation prompts (non-interactive mode)')
+    .option('-r, --recreate', 'Rebuild the tmux session even if one already exists')
     .action(async (name: string, options: OpenOptions) => {
       if (options.debug) {
         log.setLogLevel('debug');
@@ -89,6 +92,12 @@ export async function runWorktreeOpen(
     process.exit(1);
   }
 
+  if (!existsSync(worktree.path)) {
+    log.error(`Worktree directory is missing from disk: ${worktree.path}`);
+    log.info(`Clean up the stale entry with: workon worktrees remove ${worktreeName}`);
+    process.exit(1);
+  }
+
   const defaults = config.getDefaults();
   const tmux = new TmuxManager();
   const sessionName = tmux.getWorktreeSessionName(displayName, worktreeName);
@@ -121,22 +130,30 @@ export async function runWorktreeOpen(
       project,
       worktree.path,
       sessionName,
-      tmux,
-      { hasClaudeEvent, hasNpmEvent }
+      { hasClaudeEvent, hasNpmEvent },
+      options.recreate === true
     );
     console.log(shellCommands.join('\n'));
   } else {
     if (await tmux.isTmuxAvailable()) {
       try {
-        await createWorktreeTmuxSession(project, worktree.path, sessionName, tmux, {
-          hasClaudeEvent,
-          hasNpmEvent,
-        });
+        const reused = await createWorktreeTmuxSession(
+          project,
+          worktree.path,
+          sessionName,
+          tmux,
+          { hasClaudeEvent, hasNpmEvent },
+          options.recreate === true
+        );
 
         if (shouldAttach) {
           await tmux.attachToSession(sessionName);
           console.log(
-            chalk.green(`Opened worktree '${worktreeName}' in tmux session '${sessionName}'`)
+            chalk.green(
+              reused
+                ? `Attached to existing tmux session '${sessionName}' (use --recreate to rebuild it)`
+                : `Opened worktree '${worktreeName}' in tmux session '${sessionName}'`
+            )
           );
         } else {
           // Session created but not attached - return session info for caller to handle
@@ -144,7 +161,7 @@ export async function runWorktreeOpen(
             chalk.green(`\nCreated tmux session '${sessionName}' for worktree '${worktreeName}'`)
           );
           console.log(`\nTo attach to this session, run:`);
-          console.log(chalk.cyan(`  tmux attach -t '${sessionName}'`));
+          console.log(chalk.cyan(`  tmux attach -t '${sessionTarget(sessionName)}'`));
         }
       } catch (error) {
         log.error(`Failed to create tmux session: ${(error as Error).message}`);
@@ -162,8 +179,8 @@ async function buildWorktreeShellCommands(
   project: Project | null,
   worktreePath: string,
   sessionName: string,
-  tmux: TmuxManager,
-  eventFlags: { hasClaudeEvent: boolean; hasNpmEvent: boolean }
+  eventFlags: { hasClaudeEvent: boolean; hasNpmEvent: boolean },
+  recreate: boolean
 ): Promise<string[]> {
   const { hasClaudeEvent, hasNpmEvent } = eventFlags;
 
@@ -172,29 +189,59 @@ async function buildWorktreeShellCommands(
   const npmCommand = hasNpmEvent && project ? await getNpmCommand(project) : '';
 
   // Build tmux commands using a custom session name
+  let create: string[];
   if (hasClaudeEvent && hasNpmEvent && project) {
-    return buildThreePaneCommands(sessionName, worktreePath, claudeArgs, npmCommand, tmux);
+    create = buildThreePaneCommands(sessionName, worktreePath, claudeArgs, npmCommand);
   } else if (hasClaudeEvent && project) {
-    return buildSplitClaudeCommands(sessionName, worktreePath, claudeArgs, tmux);
+    create = buildSplitClaudeCommands(sessionName, worktreePath, claudeArgs);
   } else if (hasNpmEvent && project) {
-    return buildTwoPaneNpmCommands(sessionName, worktreePath, npmCommand, tmux);
+    create = buildTwoPaneNpmCommands(sessionName, worktreePath, npmCommand);
   } else {
     // Just open a shell in the worktree
-    return buildSimpleSessionCommands(sessionName, worktreePath, tmux);
+    create = buildSimpleSessionCommands(sessionName, worktreePath);
   }
+
+  const target = sessionTarget(sessionName);
+  const commands = [`# workon worktree session: ${sessionName}`];
+
+  if (recreate) {
+    commands.push(
+      `if tmux has-session -t '${target}' 2>/dev/null; then`,
+      `  tmux kill-session -t '${target}'`,
+      `fi`
+    );
+  }
+
+  // Reuse a live session rather than tearing it down - it may have an editor or
+  // a long-running agent in it that the user did not ask to lose.
+  commands.push(`if ! tmux has-session -t '${target}' 2>/dev/null; then`);
+  commands.push(...create.map((cmd) => `  ${cmd}`));
+  commands.push(`fi`);
+  commands.push(getAttachCommand(sessionName));
+
+  return commands;
 }
 
+/**
+ * Create the tmux session for a worktree.
+ * Returns true when an existing session was reused instead of rebuilt.
+ */
 async function createWorktreeTmuxSession(
   project: Project | null,
   worktreePath: string,
   sessionName: string,
   tmux: TmuxManager,
-  eventFlags: { hasClaudeEvent: boolean; hasNpmEvent: boolean }
-): Promise<void> {
+  eventFlags: { hasClaudeEvent: boolean; hasNpmEvent: boolean },
+  recreate: boolean
+): Promise<boolean> {
   const { hasClaudeEvent, hasNpmEvent } = eventFlags;
 
-  // Kill existing session if it exists
-  if (await tmux.sessionExists(sessionName)) {
+  const exists = await tmux.sessionExists(sessionName);
+  if (exists) {
+    if (!recreate) {
+      // Reuse it: rebuilding would kill whatever is running in there.
+      return true;
+    }
     await tmux.killSession(sessionName);
   }
 
@@ -202,16 +249,24 @@ async function createWorktreeTmuxSession(
   const claudeArgs = hasClaudeEvent && project ? getClaudeArgs(project) : [];
   const npmCommand = hasNpmEvent && project ? await getNpmCommand(project) : '';
 
-  // Create appropriate session based on events
-  if (hasClaudeEvent && hasNpmEvent && project) {
-    await createThreePaneSession(sessionName, worktreePath, claudeArgs, npmCommand);
-  } else if (hasClaudeEvent && project) {
-    await createSplitClaudeSession(sessionName, worktreePath, claudeArgs);
-  } else if (hasNpmEvent && project) {
-    await createTwoPaneNpmSession(sessionName, worktreePath, npmCommand);
-  } else {
-    await createSimpleSession(sessionName, worktreePath);
+  try {
+    // Create appropriate session based on events
+    if (hasClaudeEvent && hasNpmEvent && project) {
+      await createThreePaneSession(sessionName, worktreePath, claudeArgs, npmCommand);
+    } else if (hasClaudeEvent && project) {
+      await createSplitClaudeSession(sessionName, worktreePath, claudeArgs);
+    } else if (hasNpmEvent && project) {
+      await createTwoPaneNpmSession(sessionName, worktreePath, npmCommand);
+    } else {
+      await createSimpleSession(sessionName, worktreePath);
+    }
+  } catch (error) {
+    // Don't leave a half-built session behind for the next run to reuse.
+    await tmux.killSession(sessionName);
+    throw error;
   }
+
+  return false;
 }
 
 function getClaudeArgs(project: Project): string[] {
@@ -234,27 +289,17 @@ function wrapWithShellFallback(command: string): string {
   return `${command}; exec $SHELL`;
 }
 
-function buildSimpleSessionCommands(
-  sessionName: string,
-  path: string,
-  _tmux: TmuxManager
-): string[] {
+function buildSimpleSessionCommands(sessionName: string, path: string): string[] {
   const escapedSession = escapeForSingleQuotes(sessionName);
   const escapedPath = escapeForSingleQuotes(path);
 
-  return [
-    `# Create tmux session for worktree`,
-    `tmux has-session -t '${escapedSession}' 2>/dev/null && tmux kill-session -t '${escapedSession}'`,
-    `tmux new-session -d -s '${escapedSession}' -c '${escapedPath}'`,
-    getAttachCommand(sessionName),
-  ];
+  return [`tmux new-session -d -s '${escapedSession}' -c '${escapedPath}'`];
 }
 
 function buildSplitClaudeCommands(
   sessionName: string,
   path: string,
-  claudeArgs: string[],
-  _tmux: TmuxManager
+  claudeArgs: string[]
 ): string[] {
   const escapedSession = escapeForSingleQuotes(sessionName);
   const escapedPath = escapeForSingleQuotes(path);
@@ -262,32 +307,21 @@ function buildSplitClaudeCommands(
   const wrappedClaudeCmd = escapeForSingleQuotes(wrapWithShellFallback(claudeCommand));
 
   return [
-    `# Create tmux split session for worktree`,
-    `tmux has-session -t '${escapedSession}' 2>/dev/null && tmux kill-session -t '${escapedSession}'`,
     `tmux new-session -d -s '${escapedSession}' -c '${escapedPath}' '${wrappedClaudeCmd}'`,
-    `tmux split-window -h -t '${escapedSession}' -c '${escapedPath}'`,
-    `tmux select-pane -t '${escapedSession}:0.0'`,
-    getAttachCommand(sessionName),
+    `tmux split-window -h -t '${paneTarget(sessionName)}' -c '${escapedPath}'`,
+    `tmux select-pane -t '${paneTarget(sessionName, '0.0')}'`,
   ];
 }
 
-function buildTwoPaneNpmCommands(
-  sessionName: string,
-  path: string,
-  npmCommand: string,
-  _tmux: TmuxManager
-): string[] {
+function buildTwoPaneNpmCommands(sessionName: string, path: string, npmCommand: string): string[] {
   const escapedSession = escapeForSingleQuotes(sessionName);
   const escapedPath = escapeForSingleQuotes(path);
   const wrappedNpmCmd = escapeForSingleQuotes(wrapWithShellFallback(npmCommand));
 
   return [
-    `# Create tmux two-pane session with npm for worktree`,
-    `tmux has-session -t '${escapedSession}' 2>/dev/null && tmux kill-session -t '${escapedSession}'`,
     `tmux new-session -d -s '${escapedSession}' -c '${escapedPath}'`,
-    `tmux split-window -h -t '${escapedSession}' -c '${escapedPath}' '${wrappedNpmCmd}'`,
-    `tmux select-pane -t '${escapedSession}:0.0'`,
-    getAttachCommand(sessionName),
+    `tmux split-window -h -t '${paneTarget(sessionName)}' -c '${escapedPath}' '${wrappedNpmCmd}'`,
+    `tmux select-pane -t '${paneTarget(sessionName, '0.0')}'`,
   ];
 }
 
@@ -295,8 +329,7 @@ function buildThreePaneCommands(
   sessionName: string,
   path: string,
   claudeArgs: string[],
-  npmCommand: string,
-  _tmux: TmuxManager
+  npmCommand: string
 ): string[] {
   const escapedSession = escapeForSingleQuotes(sessionName);
   const escapedPath = escapeForSingleQuotes(path);
@@ -305,22 +338,19 @@ function buildThreePaneCommands(
   const wrappedNpmCmd = escapeForSingleQuotes(wrapWithShellFallback(npmCommand));
 
   return [
-    `# Create tmux three-pane session for worktree`,
-    `tmux has-session -t '${escapedSession}' 2>/dev/null && tmux kill-session -t '${escapedSession}'`,
     `tmux new-session -d -s '${escapedSession}' -c '${escapedPath}' '${wrappedClaudeCmd}'`,
-    `tmux split-window -h -t '${escapedSession}' -c '${escapedPath}'`,
-    `tmux split-window -v -t '${escapedSession}:0.1' -c '${escapedPath}' '${wrappedNpmCmd}'`,
-    `tmux resize-pane -t '${escapedSession}:0.2' -y 10`,
-    `tmux select-pane -t '${escapedSession}:0.0'`,
-    getAttachCommand(sessionName),
+    `tmux split-window -h -t '${paneTarget(sessionName)}' -c '${escapedPath}'`,
+    `tmux split-window -v -t '${paneTarget(sessionName, '0.1')}' -c '${escapedPath}' '${wrappedNpmCmd}'`,
+    `tmux resize-pane -t '${paneTarget(sessionName, '0.2')}' -y 10`,
+    `tmux select-pane -t '${paneTarget(sessionName, '0.0')}'`,
   ];
 }
 
 function getAttachCommand(sessionName: string): string {
-  const escapedSession = escapeForSingleQuotes(sessionName);
+  const target = sessionTarget(sessionName);
 
   if (process.env.TMUX) {
-    return `tmux switch-client -t '${escapedSession}'`;
+    return `tmux switch-client -t '${target}'`;
   }
 
   const isITerm =
@@ -330,9 +360,9 @@ function getAttachCommand(sessionName: string): string {
   const useiTermIntegration = isITerm && !process.env.TMUX_CC_NOT_SUPPORTED;
 
   if (useiTermIntegration) {
-    return `tmux -CC attach-session -t '${escapedSession}'`;
+    return `tmux -CC attach-session -t '${target}'`;
   }
-  return `tmux attach-session -t '${escapedSession}'`;
+  return `tmux attach-session -t '${target}'`;
 }
 
 // Direct session creation functions using exec
@@ -361,8 +391,8 @@ async function createSplitClaudeSession(
   await exec(
     `tmux new-session -d -s '${escapedSession}' -c '${escapedPath}' '${wrappedClaudeCmd}'`
   );
-  await exec(`tmux split-window -h -t '${escapedSession}' -c '${escapedPath}'`);
-  await exec(`tmux select-pane -t '${escapedSession}:0.0'`);
+  await exec(`tmux split-window -h -t '${paneTarget(sessionName)}' -c '${escapedPath}'`);
+  await exec(`tmux select-pane -t '${paneTarget(sessionName, '0.0')}'`);
 }
 
 async function createTwoPaneNpmSession(
@@ -375,8 +405,10 @@ async function createTwoPaneNpmSession(
   const wrappedNpmCmd = escapeForSingleQuotes(wrapWithShellFallback(npmCommand));
 
   await exec(`tmux new-session -d -s '${escapedSession}' -c '${escapedPath}'`);
-  await exec(`tmux split-window -h -t '${escapedSession}' -c '${escapedPath}' '${wrappedNpmCmd}'`);
-  await exec(`tmux select-pane -t '${escapedSession}:0.0'`);
+  await exec(
+    `tmux split-window -h -t '${paneTarget(sessionName)}' -c '${escapedPath}' '${wrappedNpmCmd}'`
+  );
+  await exec(`tmux select-pane -t '${paneTarget(sessionName, '0.0')}'`);
 }
 
 async function createThreePaneSession(
@@ -394,10 +426,10 @@ async function createThreePaneSession(
   await exec(
     `tmux new-session -d -s '${escapedSession}' -c '${escapedPath}' '${wrappedClaudeCmd}'`
   );
-  await exec(`tmux split-window -h -t '${escapedSession}' -c '${escapedPath}'`);
+  await exec(`tmux split-window -h -t '${paneTarget(sessionName)}' -c '${escapedPath}'`);
   await exec(
-    `tmux split-window -v -t '${escapedSession}:0.1' -c '${escapedPath}' '${wrappedNpmCmd}'`
+    `tmux split-window -v -t '${paneTarget(sessionName, '0.1')}' -c '${escapedPath}' '${wrappedNpmCmd}'`
   );
-  await exec(`tmux resize-pane -t '${escapedSession}:0.2' -y 10`);
-  await exec(`tmux select-pane -t '${escapedSession}:0.0'`);
+  await exec(`tmux resize-pane -t '${paneTarget(sessionName, '0.2')}' -y 10`);
+  await exec(`tmux select-pane -t '${paneTarget(sessionName, '0.0')}'`);
 }

--- a/src/commands/worktrees/remove.ts
+++ b/src/commands/worktrees/remove.ts
@@ -64,6 +64,14 @@ export function createRemoveCommand(ctx: WorktreesContext): Command {
         process.exit(1);
       }
 
+      // `get()` matches by branch too, so a name can resolve to a worktree
+      // workon never created. Removing one deletes its directory, so say so.
+      const isManaged = manager.isManaged(worktree);
+      if (!isManaged) {
+        log.warn(`'${worktree.name}' is not managed by workon (${worktree.path}).`);
+        log.warn('Removing it will delete that directory.');
+      }
+
       // Check if worktree directory exists on disk
       const pathMissing = !existsSync(worktree.path);
       if (pathMissing) {
@@ -99,7 +107,9 @@ export function createRemoveCommand(ctx: WorktreesContext): Command {
       // Confirm removal
       if (!options.yes) {
         console.log(`\n${chalk.bold('Worktree to remove:')}`);
-        console.log(`  Name:   ${chalk.cyan(worktree.name)}`);
+        console.log(
+          `  Name:   ${chalk.cyan(worktree.name)}${isManaged ? '' : chalk.yellow(' (external)')}`
+        );
         console.log(`  Branch: ${chalk.green(worktree.branch)}`);
         console.log(`  Path:   ${chalk.gray(worktree.path)}`);
         console.log();

--- a/src/commands/worktrees/utils.ts
+++ b/src/commands/worktrees/utils.ts
@@ -1,12 +1,7 @@
 import File from 'phylo';
 import path from 'path';
 import { simpleGit } from 'simple-git';
-import {
-  getWorktreesDirForProject,
-  isPathInside,
-  normalizePath,
-  resolveProjectIdentifier,
-} from '../../lib/worktree.js';
+import { getWorktreesRoot, isPathInside, normalizePath } from '../../lib/worktree.js';
 import { select, checkbox, confirm, input } from '@inquirer/prompts';
 import type { Config } from '../../lib/config.js';
 import type { Logger, ProjectConfig, EventsConfig } from '../../types/index.js';
@@ -140,7 +135,7 @@ export async function detectWorktreeContext(
       worktreePath: worktreeRoot,
       mainRepoPath,
       // Must match the name WorktreeManager.get() expects
-      worktreeName: resolveWorktreeName(entries, mainRepoPath, worktreeRoot),
+      worktreeName: resolveWorktreeName(entries, worktreeRoot),
       branch,
     };
   } catch {
@@ -152,12 +147,7 @@ export async function detectWorktreeContext(
  * Find a worktree's name from a parsed `git worktree list`
  * Mirrors WorktreeManager.parseWorktreeList so both agree on naming.
  */
-function resolveWorktreeName(
-  entries: WorktreeListEntry[],
-  mainRepoPath: string,
-  worktreePath: string
-): string {
-  const projectWorktreesDir = getWorktreesDirForProject(resolveProjectIdentifier(mainRepoPath));
+function resolveWorktreeName(entries: WorktreeListEntry[], worktreePath: string): string {
   const entry = entries.find((e) => e.path === worktreePath);
 
   if (!entry) {
@@ -165,7 +155,7 @@ function resolveWorktreeName(
     return path.basename(worktreePath);
   }
 
-  if (isPathInside(entry.path, projectWorktreesDir)) {
+  if (isPathInside(entry.path, getWorktreesRoot())) {
     // Managed worktree under ~/.workon/worktrees/{project}/
     return path.basename(entry.path);
   }

--- a/src/commands/worktrees/utils.ts
+++ b/src/commands/worktrees/utils.ts
@@ -1,7 +1,12 @@
 import File from 'phylo';
 import path from 'path';
 import { simpleGit } from 'simple-git';
-import { deriveProjectIdentifier, getWorktreesDirForProject } from '../../lib/worktree.js';
+import {
+  getWorktreesDirForProject,
+  isPathInside,
+  normalizePath,
+  resolveProjectIdentifier,
+} from '../../lib/worktree.js';
 import { select, checkbox, confirm, input } from '@inquirer/prompts';
 import type { Config } from '../../lib/config.js';
 import type { Logger, ProjectConfig, EventsConfig } from '../../types/index.js';
@@ -28,6 +33,46 @@ export interface ProjectContext {
   projectConfig: ProjectConfig | null;
   isRegistered: boolean;
   worktreeInfo: WorktreeInfo; // Info about worktree context
+}
+
+/**
+ * One entry of `git worktree list --porcelain`
+ */
+interface WorktreeListEntry {
+  path: string;
+  branch: string;
+}
+
+/**
+ * Parse `git worktree list --porcelain`. The first entry is always the main
+ * worktree (or the repository itself, for a bare repo).
+ */
+async function listWorktreeEntries(
+  git: ReturnType<typeof simpleGit>
+): Promise<WorktreeListEntry[]> {
+  const result = await git.raw(['worktree', 'list', '--porcelain']);
+  const entries: WorktreeListEntry[] = [];
+
+  for (const block of result.trim().split('\n\n')) {
+    if (!block.trim()) continue;
+
+    let wtPath = '';
+    let branch = '';
+    for (const line of block.split('\n')) {
+      if (line.startsWith('worktree ')) {
+        wtPath = line.substring('worktree '.length);
+      } else if (line.startsWith('branch ')) {
+        branch = line.substring('branch refs/heads/'.length);
+      } else if (line === 'detached') {
+        branch = '(detached)';
+      }
+    }
+    if (wtPath) {
+      entries.push({ path: wtPath, branch });
+    }
+  }
+
+  return entries;
 }
 
 /**
@@ -59,101 +104,76 @@ export async function detectWorktreeContext(
     // If git-dir and git-common-dir are different, we're in a worktree
     const isWorktree = normalizedGitDir !== normalizedCommonDir;
 
-    if (isWorktree) {
-      // We're in a worktree - find the main repo path
-      // The common dir is inside the main repo's .git folder
-      const mainRepoPath = path.dirname(normalizedCommonDir);
+    // The first entry of `git worktree list` is authoritative for the main
+    // worktree. Deriving it as dirname(--git-common-dir) is wrong for bare
+    // repositories, where the common dir is the repo itself rather than
+    // `<main>/.git`, and would hand back the repo's parent directory.
+    const entries = await listWorktreeEntries(git);
+    const mainRepoPath =
+      entries[0]?.path ??
+      (path.basename(normalizedCommonDir) === '.git'
+        ? path.dirname(normalizedCommonDir)
+        : normalizedCommonDir);
 
-      // Get current branch
-      let branch: string | null = null;
-      try {
-        branch = (await git.revparse(['--abbrev-ref', 'HEAD'])).trim();
-        if (branch === 'HEAD') branch = '(detached)';
-      } catch {
-        branch = '(detached)';
-      }
-
-      // Find the worktree name by querying git worktree list from main repo
-      // This ensures we get the correct name that WorktreeManager.get() expects
-      const worktreeName = await findWorktreeNameByPath(mainRepoPath, worktreeRoot);
-
-      return {
-        isWorktree: true,
-        worktreePath: worktreeRoot,
-        mainRepoPath,
-        worktreeName,
-        branch,
-      };
-    } else {
+    if (!isWorktree) {
       // We're in the main repository
       return {
         isWorktree: false,
         worktreePath: null,
-        mainRepoPath: worktreeRoot,
+        mainRepoPath,
         worktreeName: null,
         branch: null,
       };
     }
+
+    // Get current branch
+    let branch: string | null = null;
+    try {
+      branch = (await git.revparse(['--abbrev-ref', 'HEAD'])).trim();
+      if (branch === 'HEAD') branch = '(detached)';
+    } catch {
+      branch = '(detached)';
+    }
+
+    return {
+      isWorktree: true,
+      worktreePath: worktreeRoot,
+      mainRepoPath,
+      // Must match the name WorktreeManager.get() expects
+      worktreeName: resolveWorktreeName(entries, mainRepoPath, worktreeRoot),
+      branch,
+    };
   } catch {
     return null;
   }
 }
 
 /**
- * Find a worktree's name by its path by querying git worktree list
- * Returns the name that WorktreeManager uses (branch-derived for external worktrees)
+ * Find a worktree's name from a parsed `git worktree list`
+ * Mirrors WorktreeManager.parseWorktreeList so both agree on naming.
  */
-async function findWorktreeNameByPath(
+function resolveWorktreeName(
+  entries: WorktreeListEntry[],
   mainRepoPath: string,
   worktreePath: string
-): Promise<string | null> {
-  try {
-    const git = simpleGit(mainRepoPath);
-    const result = await git.raw(['worktree', 'list', '--porcelain']);
+): string {
+  const projectWorktreesDir = getWorktreesDirForProject(resolveProjectIdentifier(mainRepoPath));
+  const entry = entries.find((e) => e.path === worktreePath);
 
-    const blocks = result.trim().split('\n\n');
-    // Project-specific worktrees directory: ~/.workon/worktrees/{project-identifier}/
-    // Use derived identifier since we don't know if the project is registered
-    const projectIdentifier = deriveProjectIdentifier(mainRepoPath);
-    const projectWorktreesDir = getWorktreesDirForProject(projectIdentifier);
-
-    for (const block of blocks) {
-      if (!block.trim()) continue;
-
-      const lines = block.split('\n');
-      let wtPath = '';
-      let branch = '';
-
-      for (const line of lines) {
-        if (line.startsWith('worktree ')) {
-          wtPath = line.substring('worktree '.length);
-        } else if (line.startsWith('branch ')) {
-          branch = line.substring('branch refs/heads/'.length);
-        } else if (line === 'detached') {
-          branch = '(detached)';
-        }
-      }
-
-      // Check if this is the worktree we're looking for
-      if (wtPath === worktreePath) {
-        // Use the same naming logic as WorktreeManager.parseWorktreeList
-        if (wtPath.startsWith(projectWorktreesDir)) {
-          // Managed worktree under ~/.workon/worktrees/{project}/
-          return path.basename(wtPath);
-        } else {
-          // External worktree - use branch name converted to dir format, or basename
-          return branch && branch !== '(detached)'
-            ? branch.replace(/\//g, '-')
-            : path.basename(wtPath);
-        }
-      }
-    }
-
-    // Fallback to basename if not found (shouldn't happen)
-    return path.basename(worktreePath);
-  } catch {
+  if (!entry) {
+    // Shouldn't happen: git listed us as a worktree of this repo.
     return path.basename(worktreePath);
   }
+
+  if (isPathInside(entry.path, projectWorktreesDir)) {
+    // Managed worktree under ~/.workon/worktrees/{project}/
+    return path.basename(entry.path);
+  }
+
+  // External worktree - use branch name converted to dir format, or basename
+  return entry.branch && entry.branch !== '(detached)'
+    ? entry.branch.replace(/\//g, '-')
+    : path.basename(entry.path);
 }
 
 /**
@@ -201,8 +221,10 @@ export async function resolveProjectFromCwd(
       configuredPath = configPath.absolutify().path;
     }
 
-    // Compare paths
-    if (configuredPath === projectPath) {
+    // Compare paths. projectPath comes from git as a realpath, so the
+    // configured one has to be resolved too or a symlinked base directory
+    // (e.g. ~/code pointing at another volume) never matches.
+    if (normalizePath(configuredPath) === projectPath) {
       log.debug(`Found registered project '${name}' at ${projectPath}`);
       return {
         projectPath,

--- a/src/lib/tmux.ts
+++ b/src/lib/tmux.ts
@@ -15,6 +15,23 @@ function wrapWithShellFallback(command: string): string {
   return `${command}; exec $SHELL`;
 }
 
+/**
+ * tmux resolves `-t <name>` by exact match, then *prefix* match, then fnmatch.
+ * That means `-t workon-app_wt_feat` happily resolves to `workon-app_wt_feat2`
+ * when the former doesn't exist - so a kill-session could take out the wrong
+ * worktree's session. Prefixing the target with `=` forces an exact match.
+ *
+ * Session targets take `=name`; window/pane targets need the window and pane
+ * suffix as well (`=name:0.0`), since bare `=name` is not a valid pane target.
+ */
+export function sessionTarget(sessionName: string): string {
+  return `=${escapeForSingleQuotes(sessionName)}`;
+}
+
+export function paneTarget(sessionName: string, pane = ''): string {
+  return `=${escapeForSingleQuotes(sessionName)}:${pane}`;
+}
+
 export class TmuxManager {
   private sessionPrefix = 'workon-';
 
@@ -30,7 +47,7 @@ export class TmuxManager {
   async sessionExists(sessionName: string): Promise<boolean> {
     try {
       // sessionName is already sanitized by getSessionName
-      await exec(`tmux has-session -t '${escapeForSingleQuotes(sessionName)}'`);
+      await exec(`tmux has-session -t '${sessionTarget(sessionName)}'`);
       return true;
     } catch {
       return false;
@@ -53,7 +70,7 @@ export class TmuxManager {
 
   async killSession(sessionName: string): Promise<boolean> {
     try {
-      await exec(`tmux kill-session -t '${escapeForSingleQuotes(sessionName)}'`);
+      await exec(`tmux kill-session -t '${sessionTarget(sessionName)}'`);
       return true;
     } catch {
       return false;
@@ -83,10 +100,10 @@ export class TmuxManager {
     );
 
     // Split window horizontally and run shell in second pane
-    await exec(`tmux split-window -h -t '${escapedSession}' -c '${escapedPath}'`);
+    await exec(`tmux split-window -h -t '${paneTarget(sessionName)}' -c '${escapedPath}'`);
 
     // Set focus on claude pane (left pane)
-    await exec(`tmux select-pane -t '${escapedSession}:0.0'`);
+    await exec(`tmux select-pane -t '${paneTarget(sessionName, '0.0')}'`);
 
     return sessionName;
   }
@@ -116,18 +133,18 @@ export class TmuxManager {
     );
 
     // Split window vertically - creates right side (50/50 split)
-    await exec(`tmux split-window -h -t '${escapedSession}' -c '${escapedPath}'`);
+    await exec(`tmux split-window -h -t '${paneTarget(sessionName)}' -c '${escapedPath}'`);
 
     // Split the right pane horizontally - creates top-right and bottom-right (50/50 split)
     await exec(
-      `tmux split-window -v -t '${escapedSession}:0.1' -c '${escapedPath}' '${wrappedNpmCmd}'`
+      `tmux split-window -v -t '${paneTarget(sessionName, '0.1')}' -c '${escapedPath}' '${wrappedNpmCmd}'`
     );
 
     // Resize panes to ensure npm pane is visible (give it at least 10 lines)
-    await exec(`tmux resize-pane -t '${escapedSession}:0.2' -y 10`);
+    await exec(`tmux resize-pane -t '${paneTarget(sessionName, '0.2')}' -y 10`);
 
     // Set focus on claude pane (left pane)
-    await exec(`tmux select-pane -t '${escapedSession}:0.0'`);
+    await exec(`tmux select-pane -t '${paneTarget(sessionName, '0.0')}'`);
 
     return sessionName;
   }
@@ -152,22 +169,20 @@ export class TmuxManager {
 
     // Split window vertically and run npm command in right pane
     await exec(
-      `tmux split-window -h -t '${escapedSession}' -c '${escapedPath}' '${wrappedNpmCmd}'`
+      `tmux split-window -h -t '${paneTarget(sessionName)}' -c '${escapedPath}' '${wrappedNpmCmd}'`
     );
 
     // Set focus on terminal pane (left pane)
-    await exec(`tmux select-pane -t '${escapedSession}:0.0'`);
+    await exec(`tmux select-pane -t '${paneTarget(sessionName, '0.0')}'`);
 
     return sessionName;
   }
 
   async attachToSession(sessionName: string): Promise<void> {
-    const escapedSession = escapeForSingleQuotes(sessionName);
-
     // Check if we're already in a tmux session
     if (process.env.TMUX) {
       // If we're already in tmux, switch to the session
-      await exec(`tmux switch-client -t '${escapedSession}'`);
+      await exec(`tmux switch-client -t '${sessionTarget(sessionName)}'`);
     } else {
       // Check if iTerm2 integration is available
       const isITerm =
@@ -178,13 +193,13 @@ export class TmuxManager {
 
       if (useiTermIntegration) {
         // Use iTerm2 tmux integration - spawn detached to avoid blocking
-        spawn('tmux', ['-CC', 'attach-session', '-t', sessionName], {
+        spawn('tmux', ['-CC', 'attach-session', '-t', `=${sessionName}`], {
           stdio: 'inherit',
           detached: true,
         });
       } else {
         // Use regular tmux - spawn detached to avoid blocking
-        spawn('tmux', ['attach-session', '-t', sessionName], {
+        spawn('tmux', ['attach-session', '-t', `=${sessionName}`], {
           stdio: 'inherit',
           detached: true,
         });
@@ -205,10 +220,10 @@ export class TmuxManager {
 
     return [
       `# Create tmux split session for ${sanitizeForShell(projectName)}`,
-      `tmux has-session -t '${escapedSession}' 2>/dev/null && tmux kill-session -t '${escapedSession}'`,
+      `tmux has-session -t '${sessionTarget(sessionName)}' 2>/dev/null && tmux kill-session -t '${sessionTarget(sessionName)}'`,
       `tmux new-session -d -s '${escapedSession}' -c '${escapedPath}' '${wrappedClaudeCmd}'`,
-      `tmux split-window -h -t '${escapedSession}' -c '${escapedPath}'`,
-      `tmux select-pane -t '${escapedSession}:0.0'`,
+      `tmux split-window -h -t '${paneTarget(sessionName)}' -c '${escapedPath}'`,
+      `tmux select-pane -t '${paneTarget(sessionName, '0.0')}'`,
       this.getAttachCommand(sessionName),
     ];
   }
@@ -228,12 +243,12 @@ export class TmuxManager {
 
     return [
       `# Create tmux three-pane session for ${sanitizeForShell(projectName)}`,
-      `tmux has-session -t '${escapedSession}' 2>/dev/null && tmux kill-session -t '${escapedSession}'`,
+      `tmux has-session -t '${sessionTarget(sessionName)}' 2>/dev/null && tmux kill-session -t '${sessionTarget(sessionName)}'`,
       `tmux new-session -d -s '${escapedSession}' -c '${escapedPath}' '${wrappedClaudeCmd}'`,
-      `tmux split-window -h -t '${escapedSession}' -c '${escapedPath}'`,
-      `tmux split-window -v -t '${escapedSession}:0.1' -c '${escapedPath}' '${wrappedNpmCmd}'`,
-      `tmux resize-pane -t '${escapedSession}:0.2' -y 10`,
-      `tmux select-pane -t '${escapedSession}:0.0'`,
+      `tmux split-window -h -t '${paneTarget(sessionName)}' -c '${escapedPath}'`,
+      `tmux split-window -v -t '${paneTarget(sessionName, '0.1')}' -c '${escapedPath}' '${wrappedNpmCmd}'`,
+      `tmux resize-pane -t '${paneTarget(sessionName, '0.2')}' -y 10`,
+      `tmux select-pane -t '${paneTarget(sessionName, '0.0')}'`,
       this.getAttachCommand(sessionName),
     ];
   }
@@ -250,19 +265,17 @@ export class TmuxManager {
 
     return [
       `# Create tmux two-pane session with npm for ${sanitizeForShell(projectName)}`,
-      `tmux has-session -t '${escapedSession}' 2>/dev/null && tmux kill-session -t '${escapedSession}'`,
+      `tmux has-session -t '${sessionTarget(sessionName)}' 2>/dev/null && tmux kill-session -t '${sessionTarget(sessionName)}'`,
       `tmux new-session -d -s '${escapedSession}' -c '${escapedPath}'`,
-      `tmux split-window -h -t '${escapedSession}' -c '${escapedPath}' '${wrappedNpmCmd}'`,
-      `tmux select-pane -t '${escapedSession}:0.0'`,
+      `tmux split-window -h -t '${paneTarget(sessionName)}' -c '${escapedPath}' '${wrappedNpmCmd}'`,
+      `tmux select-pane -t '${paneTarget(sessionName, '0.0')}'`,
       this.getAttachCommand(sessionName),
     ];
   }
 
   private getAttachCommand(sessionName: string): string {
-    const escapedSession = escapeForSingleQuotes(sessionName);
-
     if (process.env.TMUX) {
-      return `tmux switch-client -t '${escapedSession}'`;
+      return `tmux switch-client -t '${sessionTarget(sessionName)}'`;
     }
 
     const isITerm =
@@ -272,9 +285,9 @@ export class TmuxManager {
     const useiTermIntegration = isITerm && !process.env.TMUX_CC_NOT_SUPPORTED;
 
     if (useiTermIntegration) {
-      return `tmux -CC attach-session -t '${escapedSession}'`;
+      return `tmux -CC attach-session -t '${sessionTarget(sessionName)}'`;
     }
-    return `tmux attach-session -t '${escapedSession}'`;
+    return `tmux attach-session -t '${sessionTarget(sessionName)}'`;
   }
 
   async listWorkonSessions(): Promise<string[]> {
@@ -284,7 +297,7 @@ export class TmuxManager {
         .trim()
         .split('\n')
         .filter((session) => session.startsWith(this.sessionPrefix))
-        .map((session) => session.replace(this.sessionPrefix, ''));
+        .map((session) => session.slice(this.sessionPrefix.length));
     } catch {
       return [];
     }

--- a/src/lib/worktree.ts
+++ b/src/lib/worktree.ts
@@ -1,12 +1,12 @@
-import { exec as execCallback } from 'child_process';
+import { execFile as execFileCallback } from 'child_process';
 import { promisify } from 'util';
-import { existsSync, chmodSync } from 'fs';
-import { join, basename } from 'path';
+import { existsSync, chmodSync, realpathSync } from 'fs';
+import { join, basename, relative, isAbsolute } from 'path';
 import { createHash } from 'crypto';
 import { homedir } from 'os';
-import { simpleGit, SimpleGit } from 'simple-git';
+import { simpleGit, SimpleGit, type StatusResult } from 'simple-git';
 
-const exec = promisify(execCallback);
+const execFile = promisify(execFileCallback);
 
 export interface WorktreeInfo {
   path: string;
@@ -27,11 +27,70 @@ export interface MergeOptions {
   squash?: boolean;
 }
 
+export interface MergeResult {
+  /** Branch the main worktree was on before the merge, if we moved off it */
+  previousBranch: string | null;
+  /** True when the main worktree was put back on `previousBranch` afterwards */
+  restored: boolean;
+}
+
+export interface WorktreeBranchInfo {
+  /** The branch this worktree was created for */
+  branch: string;
+  /** False when that branch no longer exists locally and would have to be recreated */
+  exists: boolean;
+}
+
+export interface HookResult {
+  stdout: string;
+  stderr: string;
+}
+
 const WORKON_DIR = '.workon';
 const WORKTREES_SUBDIR = 'worktrees';
 const HOOK_DIR = '.workon';
 const SETUP_HOOK = 'worktree-setup.sh';
 const TEARDOWN_HOOK = 'worktree-teardown.sh';
+
+/** Hooks routinely run installers; give them room and a ceiling instead of hanging forever. */
+const HOOK_TIMEOUT_MS = resolveHookTimeout();
+const HOOK_MAX_BUFFER = 32 * 1024 * 1024;
+
+function resolveHookTimeout(): number {
+  // 0 is Node's "no timeout", which is exactly what someone with a very long
+  // hook would set - so accept it instead of falling through to the default.
+  const configured = Number(process.env.WORKON_HOOK_TIMEOUT);
+  return Number.isFinite(configured) && configured >= 0 ? configured : 15 * 60 * 1000;
+}
+
+/**
+ * Run a git command whose failure is expected, and report "no result" as null.
+ *
+ * simple-git only treats a command as failed when it writes to stderr, and
+ * `--quiet` git commands exit non-zero while staying silent - so probing for a
+ * missing ref comes back as a *successful* empty string. Never infer failure
+ * from the absence of a throw here; go by the output.
+ */
+export async function gitProbe(git: SimpleGit, args: string[]): Promise<string | null> {
+  try {
+    const output = (await git.raw(args)).trim();
+    return output === '' ? null : output;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * True when `child` lives strictly inside `parent`.
+ *
+ * A plain `startsWith()` would treat `~/.workon/worktrees/app-1234abcd-old` as
+ * being inside `~/.workon/worktrees/app-1234abcd`, which misclassifies another
+ * project's worktrees as managed by this one.
+ */
+export function isPathInside(child: string, parent: string): boolean {
+  const rel = relative(parent, child);
+  return rel !== '' && !rel.startsWith('..') && !isAbsolute(rel);
+}
 
 /**
  * Generate a short hash from a path for disambiguation
@@ -41,12 +100,42 @@ function shortHash(input: string): string {
 }
 
 /**
+ * True when tracked files have been modified, staged, deleted or conflicted.
+ *
+ * Untracked files are deliberately ignored: they survive a branch switch
+ * untouched, and git refuses the checkout itself if one would be overwritten.
+ * Counting them would block merges on things like an uncommitted local script
+ * or a stray build artifact.
+ */
+function hasTrackedChanges(status: StatusResult): boolean {
+  return status.files.some((file) => !(file.index === '?' && file.working_dir === '?'));
+}
+
+/**
+ * Resolve symlinks in a path, leaving it untouched if it can't be resolved.
+ *
+ * The same project reaches us by two routes: git reports realpaths
+ * (`--show-toplevel`) while configured project paths may run through a symlink
+ * (e.g. a `~/code` link to another volume). Without normalizing, the two hash
+ * differently and the project ends up with two separate worktree directories.
+ */
+export function normalizePath(inputPath: string): string {
+  try {
+    return realpathSync(inputPath);
+  } catch {
+    // Path may not exist yet - fall back to what we were given.
+    return inputPath;
+  }
+}
+
+/**
  * Derive a unique project identifier from the project path
  * Uses basename + short hash of full path for uniqueness
  */
 export function deriveProjectIdentifier(projectPath: string): string {
-  const name = basename(projectPath);
-  const hash = shortHash(projectPath);
+  const resolved = normalizePath(projectPath);
+  const name = basename(resolved);
+  const hash = shortHash(resolved);
   return `${name}-${hash}`;
 }
 
@@ -54,7 +143,38 @@ export function deriveProjectIdentifier(projectPath: string): string {
  * Get the worktrees directory for a project
  */
 export function getWorktreesDirForProject(projectIdentifier: string): string {
-  return join(homedir(), WORKON_DIR, WORKTREES_SUBDIR, projectIdentifier);
+  // homedir() is normalized because every path it gets compared against comes
+  // back from git as a realpath.
+  return join(normalizePath(homedir()), WORKON_DIR, WORKTREES_SUBDIR, projectIdentifier);
+}
+
+/**
+ * Identifier as it was derived before paths were realpath-normalized.
+ * Only used to keep already-created worktrees reachable after an upgrade.
+ */
+function legacyProjectIdentifier(projectPath: string): string {
+  return `${basename(projectPath)}-${shortHash(projectPath)}`;
+}
+
+/**
+ * Resolve which identifier a project's worktrees actually live under.
+ *
+ * Normalizing paths changed the hash for anyone whose project path runs through
+ * a symlink. Their existing `~/.workon/worktrees/{old-id}/` would otherwise stop
+ * being recognised as managed, so keep using it when it is there.
+ */
+export function resolveProjectIdentifier(projectPath: string): string {
+  const current = deriveProjectIdentifier(projectPath);
+  if (existsSync(getWorktreesDirForProject(current))) {
+    return current;
+  }
+
+  const legacy = legacyProjectIdentifier(projectPath);
+  if (legacy !== current && existsSync(getWorktreesDirForProject(legacy))) {
+    return legacy;
+  }
+
+  return current;
 }
 
 export class WorktreeManager {
@@ -63,11 +183,14 @@ export class WorktreeManager {
   private git: SimpleGit;
 
   constructor(projectPath: string, _projectName?: string) {
-    this.projectPath = projectPath;
+    // Store the resolved path: `git worktree list` reports realpaths, and
+    // parseWorktreeList compares against this to find the main worktree.
+    this.projectPath = normalizePath(projectPath);
     // Always use derived identifier for consistency between creation and detection
     // The project name parameter is kept for potential future use (e.g., display)
-    this.projectIdentifier = deriveProjectIdentifier(projectPath);
-    this.git = simpleGit(projectPath);
+    // Derived from the path as given, so a pre-normalization directory still resolves.
+    this.projectIdentifier = resolveProjectIdentifier(projectPath);
+    this.git = simpleGit(this.projectPath);
   }
 
   /**
@@ -87,7 +210,7 @@ export class WorktreeManager {
    * Stored at ~/.workon/worktrees/{project-identifier}/
    */
   getWorktreesDir(): string {
-    return join(homedir(), WORKON_DIR, WORKTREES_SUBDIR, this.projectIdentifier);
+    return getWorktreesDirForProject(this.projectIdentifier);
   }
 
   /**
@@ -111,7 +234,7 @@ export class WorktreeManager {
   async listManagedWorktrees(): Promise<WorktreeInfo[]> {
     const all = await this.list();
     const worktreesDir = this.getWorktreesDir();
-    return all.filter((wt) => wt.path.startsWith(worktreesDir));
+    return all.filter((wt) => isPathInside(wt.path, worktreesDir));
   }
 
   /**
@@ -136,12 +259,32 @@ export class WorktreeManager {
     const worktreePath = join(this.getWorktreesDir(), dirName);
 
     // Check if worktree already exists
-    const existing = await this.get(dirName);
+    let existing = await this.get(dirName);
+
+    if (existing && !existsSync(existing.path)) {
+      // The directory was deleted outside of workon (rm -rf, disk cleanup...).
+      // Prune the stale registration so this add can proceed instead of failing
+      // on a worktree that no longer exists.
+      await this.git.raw(['worktree', 'prune']);
+      existing = await this.get(dirName);
+      if (existing) {
+        await this.git.raw(['worktree', 'remove', '--force', existing.path]);
+        existing = null;
+      }
+    }
+
     if (existing) {
       if (!force) {
         throw new Error(`Worktree '${dirName}' already exists at ${existing.path}`);
       }
-      // Force specified: remove existing worktree first
+      // Force specified: replace it, but never silently discard work in progress.
+      if (await this.hasUncommittedChanges(existing.path)) {
+        throw new Error(
+          `Worktree '${dirName}' has uncommitted changes at ${existing.path}. ` +
+            `Commit or stash them, or remove it explicitly with ` +
+            `'workon worktrees remove ${dirName} --force'.`
+        );
+      }
       await this.git.raw(['worktree', 'remove', '--force', existing.path]);
     }
 
@@ -261,12 +404,107 @@ export class WorktreeManager {
   }
 
   /**
-   * Merge a worktree's branch into a target branch
+   * True when this worktree lives in the directory workon manages for the project.
+   * Anything else was created by hand with `git worktree add` and is not ours.
    */
-  async merge(name: string, options: MergeOptions): Promise<void> {
+  isManaged(worktree: WorktreeInfo): boolean {
+    return isPathInside(worktree.path, this.getWorktreesDir());
+  }
+
+  /**
+   * Find the worktree (if any) that currently has `branch` checked out.
+   * git refuses to check a branch out in two places at once, so callers use
+   * this to fail with a useful message instead of a raw git fatal.
+   */
+  async getWorktreeForBranch(branch: string): Promise<WorktreeInfo | null> {
+    const worktrees = await this.list();
+    return worktrees.find((wt) => wt.branch === branch) || null;
+  }
+
+  /**
+   * Resolve the branch a worktree was *created for*.
+   *
+   * `git worktree list` reports the branch that is checked out right now, which
+   * may have moved on (e.g. after `workon worktrees branch <wt> pr-branch`).
+   * Managed worktree directories are named after their original branch via
+   * `branchToDir()`, so for those we map the directory name back to a local
+   * branch.
+   *
+   * The branch may have been deleted since - typically cleaned up after it was
+   * merged - which is why the result reports whether it still exists rather
+   * than quietly falling back to whatever happens to be checked out.
+   */
+  async getOriginalBranch(name: string): Promise<WorktreeBranchInfo | null> {
+    const worktree = await this.get(name);
+    if (!worktree) {
+      return null;
+    }
+
+    const currentBranch =
+      worktree.branch && worktree.branch !== '(detached)' ? worktree.branch : null;
+
+    if (!this.isManaged(worktree)) {
+      // External worktrees have no naming convention to reason from.
+      return currentBranch ? { branch: currentBranch, exists: true } : null;
+    }
+
+    const dirName = basename(worktree.path);
+    const branches = await this.getBranches();
+
+    // Exact match wins: 'feat-x' the branch beats 'feat/x' mapping to 'feat-x'.
+    if (branches.includes(dirName)) {
+      return { branch: dirName, exists: true };
+    }
+    const mapped = branches.find((b) => this.branchToDir(b) === dirName);
+    if (mapped) {
+      return { branch: mapped, exists: true };
+    }
+
+    // The worktree's own branch is gone (usually cleaned up after merging).
+    // The directory name is a flattened form of it, so check the remote for the
+    // real name before falling back - that's the only way to recover the
+    // slashes in something like 'feature/login'.
+    const remoteMatch = (await this.getRemoteBranchNames()).find(
+      (b) => this.branchToDir(b) === dirName
+    );
+
+    return { branch: remoteMatch || dirName, exists: false };
+  }
+
+  /**
+   * Local names of remote-tracking branches ('origin/feature/x' -> 'feature/x').
+   */
+  private async getRemoteBranchNames(): Promise<string[]> {
+    // Read the raw output: simple-git's branch() parser returns nothing at all
+    // when given a custom --format.
+    const output = await gitProbe(this.git, ['branch', '-r', '--format=%(refname:short)']);
+    if (!output) {
+      return [];
+    }
+
+    return output
+      .split('\n')
+      .map((line) => line.trim())
+      .filter((ref) => ref && !ref.endsWith('/HEAD')) // skip the origin/HEAD alias
+      .map((ref) => ref.split('/').slice(1).join('/'))
+      .filter(Boolean);
+  }
+
+  /**
+   * Merge a worktree's branch into a target branch.
+   *
+   * The merge happens in the main worktree, so this both requires it to be clean
+   * and puts it back on the branch it started on - leaving someone's main
+   * checkout silently parked on `targetBranch` is a nasty surprise.
+   */
+  async merge(name: string, options: MergeOptions): Promise<MergeResult> {
     const worktree = await this.get(name);
     if (!worktree) {
       throw new Error(`Worktree '${name}' not found`);
+    }
+
+    if (!worktree.branch || worktree.branch === '(detached)') {
+      throw new Error(`Worktree '${name}' is in detached HEAD state and has no branch to merge`);
     }
 
     const { targetBranch, squash } = options;
@@ -276,21 +514,98 @@ export class WorktreeManager {
       throw new Error(`Target branch '${targetBranch}' does not exist`);
     }
 
-    // Checkout target branch in main worktree
+    if (targetBranch === worktree.branch) {
+      throw new Error(`Cannot merge '${worktree.branch}' into itself`);
+    }
+
+    // A dirty main worktree would either block the checkout or drag local
+    // changes onto the target branch mid-merge.
+    const mainStatus = await this.git.status();
+    if (hasTrackedChanges(mainStatus)) {
+      throw new Error(
+        'The main worktree has uncommitted changes. Commit or stash them before merging.'
+      );
+    }
+
+    // git only allows one checkout of a branch across all worktrees.
+    const holder = await this.getWorktreeForBranch(targetBranch);
+    if (holder && !holder.isMain) {
+      throw new Error(
+        `Branch '${targetBranch}' is checked out in worktree '${holder.name}' (${holder.path}). ` +
+          `Switch that worktree to another branch first.`
+      );
+    }
+
+    const previousBranch = await this.getCurrentBranch();
+    const shouldRestore = previousBranch !== targetBranch && previousBranch !== 'HEAD';
+
     await this.git.checkout(targetBranch);
 
-    // Merge the worktree's branch
-    const mergeArgs = ['merge'];
-    if (squash) {
-      mergeArgs.push('--squash');
+    try {
+      // --no-edit keeps git from trying to open an editor for the merge message.
+      const mergeArgs = ['merge', '--no-edit'];
+      if (squash) {
+        mergeArgs.push('--squash');
+      }
+      mergeArgs.push(worktree.branch);
+
+      await this.git.raw(mergeArgs);
+
+      // simple-git only reports a command as failed when it writes to stderr,
+      // and git announces merge conflicts on stdout - so a conflicted merge
+      // comes back looking like a success. Inspect the result instead of
+      // trusting that: reporting a conflicted merge as done is how a caller
+      // ends up deleting the worktree and branch whose work never landed.
+      const postStatus = await this.git.status();
+      if (postStatus.conflicted.length > 0) {
+        throw new Error(
+          `Merge conflict in ${postStatus.conflicted.length} file(s): ` +
+            `${postStatus.conflicted.join(', ')}`
+        );
+      }
+
+      // A squash merge only stages the result; it still needs a commit.
+      if (squash) {
+        if (postStatus.isClean()) {
+          throw new Error(
+            `Nothing to merge: '${worktree.branch}' is already contained in '${targetBranch}'`
+          );
+        }
+        await this.git.commit(`Merge ${worktree.branch} into ${targetBranch} (squashed)`);
+      }
+    } catch (error) {
+      // Don't strand the main worktree mid-merge. We verified it was clean
+      // above, so discarding the failed merge state loses nothing.
+      await this.abortMerge();
+      if (shouldRestore) {
+        await this.git.checkout(previousBranch).catch(() => {});
+      }
+      throw error;
     }
-    mergeArgs.push(worktree.branch);
 
-    await this.git.raw(mergeArgs);
+    if (shouldRestore) {
+      await this.git.checkout(previousBranch);
+    }
 
-    // If squash merge, we need to commit
-    if (squash) {
-      await this.git.commit(`Merge ${worktree.branch} into ${targetBranch} (squashed)`);
+    return { previousBranch, restored: shouldRestore };
+  }
+
+  /**
+   * Roll back an in-progress merge in the main worktree.
+   * `merge --abort` handles a normal merge; a conflicted `--squash` merge has no
+   * MERGE_HEAD to abort, so it needs a hard reset instead.
+   */
+  private async abortMerge(): Promise<void> {
+    try {
+      await this.git.raw(['merge', '--abort']);
+      return;
+    } catch {
+      // Not a normal merge in progress - fall through.
+    }
+    try {
+      await this.git.raw(['reset', '--hard', 'HEAD']);
+    } catch {
+      // Nothing else we can safely do; the original error is what matters.
     }
   }
 
@@ -312,32 +627,8 @@ export class WorktreeManager {
   /**
    * Run the post-setup hook for a worktree
    */
-  async runPostSetupHook(worktreePath: string): Promise<{ stdout: string; stderr: string }> {
-    const hookPath = this.getSetupHookPath();
-
-    if (!existsSync(hookPath)) {
-      throw new Error('Setup hook not found');
-    }
-
-    // Ensure hook is executable
-    try {
-      chmodSync(hookPath, '755');
-    } catch {
-      // Ignore chmod errors on systems that don't support it
-    }
-
-    const env = {
-      ...process.env,
-      WORKTREE_PATH: worktreePath,
-      PROJECT_PATH: this.projectPath,
-    };
-
-    const { stdout, stderr } = await exec(hookPath, {
-      cwd: worktreePath,
-      env,
-    });
-
-    return { stdout, stderr };
+  async runPostSetupHook(worktreePath: string): Promise<HookResult> {
+    return this.runHook(this.getSetupHookPath(), 'Setup', worktreePath);
   }
 
   /**
@@ -358,16 +649,31 @@ export class WorktreeManager {
   /**
    * Run the pre-teardown hook for a worktree
    */
-  async runPreTeardownHook(worktreePath: string): Promise<{ stdout: string; stderr: string }> {
-    const hookPath = this.getTeardownHookPath();
+  async runPreTeardownHook(worktreePath: string): Promise<HookResult> {
+    return this.runHook(this.getTeardownHookPath(), 'Teardown', worktreePath);
+  }
 
+  /**
+   * Execute a worktree hook script.
+   *
+   * Uses execFile rather than exec so the hook path is passed as an argv entry:
+   * a project living in a directory with a space (or any shell metacharacter)
+   * would otherwise be word-split by /bin/sh and fail - or worse, run something
+   * unintended. Hooks commonly run installers, so they also get a generous
+   * output buffer and a timeout instead of an unbounded wait.
+   */
+  private async runHook(hookPath: string, kind: string, worktreePath: string): Promise<HookResult> {
     if (!existsSync(hookPath)) {
-      throw new Error('Teardown hook not found');
+      throw new Error(`${kind} hook not found at ${hookPath}`);
+    }
+
+    if (!existsSync(worktreePath)) {
+      throw new Error(`Worktree directory no longer exists: ${worktreePath}`);
     }
 
     // Ensure hook is executable
     try {
-      chmodSync(hookPath, '755');
+      chmodSync(hookPath, 0o755);
     } catch {
       // Ignore chmod errors on systems that don't support it
     }
@@ -376,14 +682,85 @@ export class WorktreeManager {
       ...process.env,
       WORKTREE_PATH: worktreePath,
       PROJECT_PATH: this.projectPath,
+      WORKTREE_NAME: basename(worktreePath),
     };
 
-    const { stdout, stderr } = await exec(hookPath, {
-      cwd: worktreePath,
-      env,
-    });
+    try {
+      const { stdout, stderr } = await execFile(hookPath, [], {
+        cwd: worktreePath,
+        env,
+        timeout: HOOK_TIMEOUT_MS,
+        maxBuffer: HOOK_MAX_BUFFER,
+        encoding: 'utf8',
+      });
+      return { stdout, stderr };
+    } catch (error) {
+      const err = error as NodeJS.ErrnoException & {
+        killed?: boolean;
+        stderr?: string;
+        stdout?: string;
+      };
 
-    return { stdout, stderr };
+      if (err.killed) {
+        throw new Error(
+          `${kind} hook timed out after ${Math.round(HOOK_TIMEOUT_MS / 1000)}s ` +
+            `(override with WORKON_HOOK_TIMEOUT, in milliseconds)`
+        );
+      }
+      if (err.code === 'ENOENT') {
+        throw new Error(`${kind} hook could not be executed: ${hookPath}`);
+      }
+      if (err.code === 'EACCES') {
+        throw new Error(`${kind} hook is not executable: chmod +x ${hookPath}`);
+      }
+      if (err.code === 'ENOEXEC') {
+        // `exec()` used to hand the file to /bin/sh, which happily interprets a
+        // shebang-less script. execFile can't, so run it under sh explicitly
+        // rather than breaking hooks that have always worked.
+        return this.runHookUnderShell(hookPath, kind, worktreePath, env);
+      }
+
+      throw this.hookFailure(kind, err);
+    }
+  }
+
+  /**
+   * Fallback for hooks with no `#!` line, which only run because a shell is
+   * willing to interpret them.
+   */
+  private async runHookUnderShell(
+    hookPath: string,
+    kind: string,
+    worktreePath: string,
+    env: NodeJS.ProcessEnv
+  ): Promise<HookResult> {
+    try {
+      const { stdout, stderr } = await execFile('/bin/sh', [hookPath], {
+        cwd: worktreePath,
+        env,
+        timeout: HOOK_TIMEOUT_MS,
+        maxBuffer: HOOK_MAX_BUFFER,
+        encoding: 'utf8',
+      });
+      return { stdout, stderr };
+    } catch (error) {
+      throw this.hookFailure(kind, error as NodeJS.ErrnoException);
+    }
+  }
+
+  /** Surface the hook's own diagnostics; the raw error is just an exit code. */
+  private hookFailure(
+    kind: string,
+    err: NodeJS.ErrnoException & { killed?: boolean; stderr?: string; stdout?: string }
+  ): Error {
+    if (err.killed) {
+      return new Error(
+        `${kind} hook timed out after ${Math.round(HOOK_TIMEOUT_MS / 1000)}s ` +
+          `(override with WORKON_HOOK_TIMEOUT, in milliseconds)`
+      );
+    }
+    const detail = (err.stderr || err.stdout || '').trim();
+    return new Error(detail ? `${kind} hook failed:\n${detail}` : `${kind} hook failed`);
   }
 
   /**
@@ -421,7 +798,7 @@ export class WorktreeManager {
         // Calculate name from path
         const worktreesDir = this.getWorktreesDir();
         let name: string;
-        if (path.startsWith(worktreesDir)) {
+        if (isPathInside(path, worktreesDir)) {
           // Managed worktree under ~/.workon/worktrees/{project}/
           name = basename(path);
         } else if (path === this.projectPath) {

--- a/src/lib/worktree.ts
+++ b/src/lib/worktree.ts
@@ -59,7 +59,13 @@ const HOOK_MAX_BUFFER = 32 * 1024 * 1024;
 function resolveHookTimeout(): number {
   // 0 is Node's "no timeout", which is exactly what someone with a very long
   // hook would set - so accept it instead of falling through to the default.
-  const configured = Number(process.env.WORKON_HOOK_TIMEOUT);
+  // An empty or blank value is *not* 0: `export WORKON_HOOK_TIMEOUT=` should
+  // leave the safety net in place rather than quietly removing it.
+  const raw = process.env.WORKON_HOOK_TIMEOUT?.trim();
+  if (!raw) {
+    return 15 * 60 * 1000;
+  }
+  const configured = Number(raw);
   return Number.isFinite(configured) && configured >= 0 ? configured : 15 * 60 * 1000;
 }
 
@@ -140,41 +146,27 @@ export function deriveProjectIdentifier(projectPath: string): string {
 }
 
 /**
- * Get the worktrees directory for a project
+ * Root directory holding every project's worktrees.
+ *
+ * Whether a worktree is workon-managed is decided against this root rather than
+ * against one project's `{name}-{hash}` subdirectory. `git worktree list` only
+ * ever reports worktrees of the current repository, so anything of ours living
+ * anywhere under here is ours - which keeps recognition working regardless of
+ * which identifier a worktree was created under. That matters because the hash
+ * depends on the project path, and the path can reach us either from git (a
+ * realpath) or from config (possibly via a symlink).
  */
-export function getWorktreesDirForProject(projectIdentifier: string): string {
+export function getWorktreesRoot(): string {
   // homedir() is normalized because every path it gets compared against comes
   // back from git as a realpath.
-  return join(normalizePath(homedir()), WORKON_DIR, WORKTREES_SUBDIR, projectIdentifier);
+  return join(normalizePath(homedir()), WORKON_DIR, WORKTREES_SUBDIR);
 }
 
 /**
- * Identifier as it was derived before paths were realpath-normalized.
- * Only used to keep already-created worktrees reachable after an upgrade.
+ * Get the worktrees directory for a project - where new worktrees are created.
  */
-function legacyProjectIdentifier(projectPath: string): string {
-  return `${basename(projectPath)}-${shortHash(projectPath)}`;
-}
-
-/**
- * Resolve which identifier a project's worktrees actually live under.
- *
- * Normalizing paths changed the hash for anyone whose project path runs through
- * a symlink. Their existing `~/.workon/worktrees/{old-id}/` would otherwise stop
- * being recognised as managed, so keep using it when it is there.
- */
-export function resolveProjectIdentifier(projectPath: string): string {
-  const current = deriveProjectIdentifier(projectPath);
-  if (existsSync(getWorktreesDirForProject(current))) {
-    return current;
-  }
-
-  const legacy = legacyProjectIdentifier(projectPath);
-  if (legacy !== current && existsSync(getWorktreesDirForProject(legacy))) {
-    return legacy;
-  }
-
-  return current;
+export function getWorktreesDirForProject(projectIdentifier: string): string {
+  return join(getWorktreesRoot(), projectIdentifier);
 }
 
 export class WorktreeManager {
@@ -188,8 +180,7 @@ export class WorktreeManager {
     this.projectPath = normalizePath(projectPath);
     // Always use derived identifier for consistency between creation and detection
     // The project name parameter is kept for potential future use (e.g., display)
-    // Derived from the path as given, so a pre-normalization directory still resolves.
-    this.projectIdentifier = resolveProjectIdentifier(projectPath);
+    this.projectIdentifier = deriveProjectIdentifier(this.projectPath);
     this.git = simpleGit(this.projectPath);
   }
 
@@ -233,8 +224,7 @@ export class WorktreeManager {
    */
   async listManagedWorktrees(): Promise<WorktreeInfo[]> {
     const all = await this.list();
-    const worktreesDir = this.getWorktreesDir();
-    return all.filter((wt) => isPathInside(wt.path, worktreesDir));
+    return all.filter((wt) => this.isManaged(wt));
   }
 
   /**
@@ -314,6 +304,9 @@ export class WorktreeManager {
     if (!worktree) {
       throw new Error('Failed to create worktree');
     }
+
+    await this.rememberOriginalBranch(dirName, branch);
+
     return worktree;
   }
 
@@ -345,6 +338,46 @@ export class WorktreeManager {
     args.push(worktree.path);
 
     await this.git.raw(args);
+
+    await this.forgetOriginalBranch(basename(worktree.path));
+  }
+
+  /**
+   * Where a managed worktree's original branch is recorded.
+   *
+   * git splits `section.subsection.key` at the first and last dot, so a
+   * directory name containing dots (`release-1.2.3`) still round-trips.
+   */
+  private originalBranchKey(dirName: string): string {
+    return `workon.worktree.${dirName}.branch`;
+  }
+
+  /**
+   * Record which branch a worktree was created for.
+   *
+   * The directory name alone can't answer this: `branchToDir()` is lossy
+   * (`feature/login` and `feature-login` both become `feature-login`), so
+   * recovering the branch from it is guesswork whenever both exist. Failing to
+   * record is not fatal - resolution falls back to that guess.
+   */
+  private async rememberOriginalBranch(dirName: string, branch: string): Promise<void> {
+    try {
+      await this.git.addConfig(this.originalBranchKey(dirName), branch);
+    } catch {
+      // Recording is best-effort; the worktree itself is already created.
+    }
+  }
+
+  private async recallOriginalBranch(dirName: string): Promise<string | null> {
+    return gitProbe(this.git, ['config', '--local', '--get', this.originalBranchKey(dirName)]);
+  }
+
+  private async forgetOriginalBranch(dirName: string): Promise<void> {
+    try {
+      await this.git.raw(['config', '--local', '--unset', this.originalBranchKey(dirName)]);
+    } catch {
+      // Nothing recorded, or already gone.
+    }
   }
 
   /**
@@ -408,7 +441,7 @@ export class WorktreeManager {
    * Anything else was created by hand with `git worktree add` and is not ours.
    */
   isManaged(worktree: WorktreeInfo): boolean {
-    return isPathInside(worktree.path, this.getWorktreesDir());
+    return isPathInside(worktree.path, getWorktreesRoot());
   }
 
   /**
@@ -451,7 +484,16 @@ export class WorktreeManager {
     const dirName = basename(worktree.path);
     const branches = await this.getBranches();
 
-    // Exact match wins: 'feat-x' the branch beats 'feat/x' mapping to 'feat-x'.
+    // What `add` recorded, when it was this version of workon that created it.
+    const remembered = await this.recallOriginalBranch(dirName);
+    if (remembered) {
+      return { branch: remembered, exists: branches.includes(remembered) };
+    }
+
+    // Older worktrees have nothing recorded, so fall back to reversing the
+    // directory name. Exact match wins - a branch literally named after the
+    // directory is the likelier intent - but note this cannot distinguish
+    // 'feature-login' from 'feature/login' when both exist.
     if (branches.includes(dirName)) {
       return { branch: dirName, exists: true };
     }
@@ -584,7 +626,13 @@ export class WorktreeManager {
     }
 
     if (shouldRestore) {
-      await this.git.checkout(previousBranch);
+      try {
+        await this.git.checkout(previousBranch);
+      } catch {
+        // The merge landed. Failing to switch back is a lesser, separate
+        // problem, and throwing here would report the merge itself as failed.
+        return { previousBranch, restored: false };
+      }
     }
 
     return { previousBranch, restored: shouldRestore };
@@ -796,9 +844,8 @@ export class WorktreeManager {
 
       if (path) {
         // Calculate name from path
-        const worktreesDir = this.getWorktreesDir();
         let name: string;
-        if (isPathInside(path, worktreesDir)) {
+        if (isPathInside(path, getWorktreesRoot())) {
           // Managed worktree under ~/.workon/worktrees/{project}/
           name = basename(path);
         } else if (path === this.projectPath) {

--- a/tests/commands/cli-index.test.ts
+++ b/tests/commands/cli-index.test.ts
@@ -22,6 +22,11 @@ vi.mock('../../src/lib/tmux.js', () => ({
 // Mock child_process
 vi.mock('child_process', () => ({
   spawn: vi.fn(() => ({ unref: vi.fn() })),
+  execFile: vi.fn((file, args, opts, callback) => {
+    const cb = [args, opts, callback].find((c) => typeof c === 'function');
+    if (cb) cb(null, '', '');
+    return { stdout: '', stderr: '' };
+  }),
   exec: vi.fn((cmd, opts, callback) => {
     // Handle both 2-arg and 3-arg versions
     const cb = typeof opts === 'function' ? opts : callback;

--- a/tests/commands/interactive.test.ts
+++ b/tests/commands/interactive.test.ts
@@ -37,6 +37,11 @@ vi.mock('child_process', () => ({
       }
     }),
   })),
+  execFile: vi.fn((file, args, opts, callback) => {
+    const cb = [args, opts, callback].find((c) => typeof c === 'function');
+    if (cb) cb(null, '', '');
+    return { stdout: '', stderr: '' };
+  }),
   exec: vi.fn((cmd, opts, callback) => {
     const cb = typeof opts === 'function' ? opts : callback;
     if (cb) cb(null, '', '');

--- a/tests/commands/open.test.ts
+++ b/tests/commands/open.test.ts
@@ -26,6 +26,14 @@ vi.mock('child_process', () => ({
   exec: vi.fn((_cmd: string, cb: (err: null, result: { stdout: string; stderr: string }) => void) =>
     cb(null, { stdout: '', stderr: '' })
   ),
+  execFile: vi.fn(
+    (
+      _file: string,
+      _args: string[],
+      _opts: unknown,
+      cb: (err: null, result: { stdout: string; stderr: string }) => void
+    ) => cb(null, { stdout: '', stderr: '' })
+  ),
 }));
 
 describe('createOpenCommand', () => {

--- a/tests/commands/worktree-recycle.test.ts
+++ b/tests/commands/worktree-recycle.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync, realpathSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { simpleGit, type SimpleGit } from 'simple-git';
+import { detectDefaultRemoteBranch, resolveRemote } from '../../src/commands/worktree.js';
+
+/**
+ * These probe git for refs that are expected to be missing. `--quiet` git
+ * commands exit non-zero *silently*, and simple-git only reports a command as
+ * failed when it writes to stderr - so a lookup that infers failure from a
+ * thrown error silently reports the first candidate for every repository.
+ */
+
+const created: string[] = [];
+
+afterAll(() => {
+  while (created.length) {
+    rmSync(created.pop() as string, { recursive: true, force: true });
+  }
+});
+
+function tempDir(prefix: string): string {
+  const dir = realpathSync(mkdtempSync(join(tmpdir(), prefix)));
+  created.push(dir);
+  return dir;
+}
+
+/** A repo with `origin` pointing at a bare repo whose default branch is `branch` */
+async function repoWithRemote(branch: string): Promise<SimpleGit> {
+  const root = tempDir(`workon-remote-${branch}-`);
+  const origin = join(root, 'origin.git');
+  const work = join(root, 'work');
+
+  await simpleGit(root).raw(['init', '--bare', origin]);
+
+  const git = simpleGit(root);
+  await git.clone(origin, work);
+  const repo = simpleGit(work);
+  await repo.addConfig('user.email', 'test@example.com');
+  await repo.addConfig('user.name', 'Test');
+  writeFileSync(join(work, 'README.md'), 'hi\n');
+  await repo.add('.');
+  await repo.commit('init');
+  await repo.raw(['branch', '-M', branch]);
+  await repo.push(['-u', 'origin', branch]);
+
+  // `git clone` of an empty repo leaves no origin/HEAD, which is also the state
+  // of any repo whose remote was added by hand.
+  await repo.raw(['remote', 'set-head', 'origin', '--delete']).catch(() => {});
+  return repo;
+}
+
+describe('detectDefaultRemoteBranch', () => {
+  let mainRepo: SimpleGit;
+  let masterRepo: SimpleGit;
+  let developRepo: SimpleGit;
+
+  beforeAll(async () => {
+    mainRepo = await repoWithRemote('main');
+    masterRepo = await repoWithRemote('master');
+    developRepo = await repoWithRemote('develop');
+  }, 60_000);
+
+  it('detects main', async () => {
+    expect(await detectDefaultRemoteBranch(mainRepo, 'origin')).toBe('main');
+  });
+
+  it('detects master rather than assuming main', async () => {
+    expect(await detectDefaultRemoteBranch(masterRepo, 'origin')).toBe('master');
+  });
+
+  it('detects develop rather than assuming main', async () => {
+    // Regression: probing with `rev-parse --verify --quiet` inside a try/catch
+    // never threw, so the first candidate ('main') was always returned.
+    expect(await detectDefaultRemoteBranch(developRepo, 'origin')).toBe('develop');
+  });
+
+  it('prefers what origin/HEAD points at', async () => {
+    const repo = await repoWithRemote('trunk-a');
+    await repo.raw(['branch', 'main']);
+    await repo.push('origin', 'main');
+    await repo.fetch();
+    await repo.raw(['remote', 'set-head', 'origin', 'trunk-a']);
+
+    expect(await detectDefaultRemoteBranch(repo, 'origin')).toBe('trunk-a');
+  }, 30_000);
+
+  it('returns null when no known default branch exists', async () => {
+    const repo = await repoWithRemote('trunk-b');
+    expect(await detectDefaultRemoteBranch(repo, 'origin')).toBeNull();
+  }, 30_000);
+});
+
+describe('resolveRemote', () => {
+  it('returns null when the repo has no remotes', async () => {
+    const dir = tempDir('workon-noremote-');
+    const git = simpleGit(dir);
+    await git.init();
+    expect(await resolveRemote(git)).toBeNull();
+  });
+
+  it('prefers origin', async () => {
+    const dir = tempDir('workon-origin-');
+    const git = simpleGit(dir);
+    await git.init();
+    await git.addRemote('upstream', 'https://example.com/u.git');
+    await git.addRemote('origin', 'https://example.com/o.git');
+    expect(await resolveRemote(git)).toBe('origin');
+  });
+
+  it('uses the only remote when it is not called origin', async () => {
+    const dir = tempDir('workon-single-');
+    const git = simpleGit(dir);
+    await git.init();
+    await git.addRemote('fork', 'https://example.com/f.git');
+    expect(await resolveRemote(git)).toBe('fork');
+  });
+
+  it('refuses to guess between several non-origin remotes', async () => {
+    const dir = tempDir('workon-many-');
+    const git = simpleGit(dir);
+    await git.init();
+    await git.addRemote('fork', 'https://example.com/f.git');
+    await git.addRemote('upstream', 'https://example.com/u.git');
+    expect(await resolveRemote(git)).toBeNull();
+  });
+});

--- a/tests/commands/worktrees/utils.test.ts
+++ b/tests/commands/worktrees/utils.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync, realpathSync, mkdirSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { simpleGit } from 'simple-git';
+import { detectWorktreeContext } from '../../../src/commands/worktrees/utils.js';
+
+const originalHome = process.env.HOME;
+const created: string[] = [];
+
+beforeAll(() => {
+  // Managed worktrees live under $HOME/.workon - keep them in a sandbox
+  const home = realpathSync(mkdtempSync(join(tmpdir(), 'workon-home-')));
+  created.push(home);
+  process.env.HOME = home;
+});
+
+afterAll(() => {
+  process.env.HOME = originalHome;
+  while (created.length) {
+    rmSync(created.pop() as string, { recursive: true, force: true });
+  }
+});
+
+function tempDir(prefix: string): string {
+  const dir = realpathSync(mkdtempSync(join(tmpdir(), prefix)));
+  created.push(dir);
+  return dir;
+}
+
+async function seedRepo(dir: string) {
+  const git = simpleGit(dir);
+  await git.init();
+  await git.addConfig('user.email', 'test@example.com');
+  await git.addConfig('user.name', 'Test');
+  writeFileSync(join(dir, 'README.md'), 'hi\n');
+  await git.add('.');
+  await git.commit('init');
+  await git.raw(['branch', '-M', 'main']);
+  return git;
+}
+
+describe('detectWorktreeContext', () => {
+  it('returns null outside a git repository', async () => {
+    expect(await detectWorktreeContext(tempDir('workon-nogit-'))).toBeNull();
+  });
+
+  it('reports the main repository', async () => {
+    const dir = tempDir('workon-main-');
+    await seedRepo(dir);
+
+    const info = await detectWorktreeContext(dir);
+    expect(info).not.toBeNull();
+    expect(info!.isWorktree).toBe(false);
+    expect(info!.mainRepoPath).toBe(dir);
+    expect(info!.worktreeName).toBeNull();
+  });
+
+  it('reports the worktree and its main repo from inside a worktree', async () => {
+    const dir = tempDir('workon-wtmain-');
+    const git = await seedRepo(dir);
+    const wtRoot = tempDir('workon-wtroot-');
+    const wtPath = join(wtRoot, 'feat-a');
+    await git.raw(['worktree', 'add', '-b', 'feat/a', wtPath]);
+
+    const info = await detectWorktreeContext(wtPath);
+    expect(info!.isWorktree).toBe(true);
+    expect(info!.mainRepoPath).toBe(dir);
+    expect(info!.worktreePath).toBe(realpathSync(wtPath));
+    expect(info!.branch).toBe('feat/a');
+    // External worktree: named after its branch, in directory form
+    expect(info!.worktreeName).toBe('feat-a');
+  });
+
+  it('resolves the main repo for a worktree of a bare repository', async () => {
+    // Regression: mainRepoPath was dirname(--git-common-dir), which for a bare
+    // repo pointed at the repo's *parent* directory rather than the repo.
+    const parent = tempDir('workon-bare-');
+    const source = join(parent, 'source');
+    const bare = join(parent, 'repo.git');
+    mkdirSync(source);
+    await seedRepo(source);
+    await simpleGit(parent).clone(source, bare, ['--bare']);
+
+    const wtPath = join(parent, 'feat-b');
+    await simpleGit(bare).raw(['worktree', 'add', '-b', 'feat-b', wtPath]);
+
+    const info = await detectWorktreeContext(wtPath);
+    expect(info!.isWorktree).toBe(true);
+    expect(info!.mainRepoPath).toBe(realpathSync(bare));
+    expect(info!.mainRepoPath).not.toBe(parent);
+  });
+
+  it('detects a subdirectory of a worktree as that worktree', async () => {
+    const dir = tempDir('workon-sub-');
+    const git = await seedRepo(dir);
+    const wtRoot = tempDir('workon-subwt-');
+    const wtPath = join(wtRoot, 'feat-c');
+    await git.raw(['worktree', 'add', '-b', 'feat-c', wtPath]);
+    const nested = join(wtPath, 'src');
+    mkdirSync(nested);
+
+    const info = await detectWorktreeContext(nested);
+    expect(info!.isWorktree).toBe(true);
+    expect(info!.worktreePath).toBe(realpathSync(wtPath));
+    expect(info!.mainRepoPath).toBe(dir);
+  });
+});

--- a/tests/lib/tmux.test.ts
+++ b/tests/lib/tmux.test.ts
@@ -35,15 +35,15 @@ describe('TmuxManager', () => {
 
       expect(commands).toContain('# Create tmux split session for myproject');
       expect(commands).toContain(
-        "tmux has-session -t 'workon-myproject' 2>/dev/null && tmux kill-session -t 'workon-myproject'"
+        "tmux has-session -t '=workon-myproject' 2>/dev/null && tmux kill-session -t '=workon-myproject'"
       );
       expect(commands).toContain(
         "tmux new-session -d -s 'workon-myproject' -c '/path/to/project' 'claude; exec $SHELL'"
       );
       expect(commands).toContain(
-        "tmux split-window -h -t 'workon-myproject' -c '/path/to/project'"
+        "tmux split-window -h -t '=workon-myproject:' -c '/path/to/project'"
       );
-      expect(commands).toContain("tmux select-pane -t 'workon-myproject:0.0'");
+      expect(commands).toContain("tmux select-pane -t '=workon-myproject:0.0'");
     });
 
     it('should include claude flags when provided', () => {
@@ -67,7 +67,7 @@ describe('TmuxManager', () => {
       vi.stubEnv('TMUX', '/tmp/tmux-123/default,456,0');
       const newTmux = new TmuxManager();
       const commands = newTmux.buildShellCommands('myproject', '/path/to/project');
-      expect(commands).toContain("tmux switch-client -t 'workon-myproject'");
+      expect(commands).toContain("tmux switch-client -t '=workon-myproject'");
     });
   });
 
@@ -81,9 +81,9 @@ describe('TmuxManager', () => {
 
       expect(commands).toContain('# Create tmux three-pane session for myproject');
       expect(commands).toContain(
-        "tmux split-window -v -t 'workon-myproject:0.1' -c '/path/to/project' 'npm run dev; exec $SHELL'"
+        "tmux split-window -v -t '=workon-myproject:0.1' -c '/path/to/project' 'npm run dev; exec $SHELL'"
       );
-      expect(commands).toContain("tmux resize-pane -t 'workon-myproject:0.2' -y 10");
+      expect(commands).toContain("tmux resize-pane -t '=workon-myproject:0.2' -y 10");
     });
 
     it('should use custom npm command', () => {
@@ -117,7 +117,7 @@ describe('TmuxManager', () => {
         "tmux new-session -d -s 'workon-myproject' -c '/path/to/project'"
       );
       expect(commands).toContain(
-        "tmux split-window -h -t 'workon-myproject' -c '/path/to/project' 'npm run dev; exec $SHELL'"
+        "tmux split-window -h -t '=workon-myproject:' -c '/path/to/project' 'npm run dev; exec $SHELL'"
       );
     });
 
@@ -143,7 +143,7 @@ describe('TmuxManager', () => {
 
       const newTmux = new TmuxManager();
       const commands = newTmux.buildShellCommands('myproject', '/path/to/project');
-      expect(commands).toContain("tmux -CC attach-session -t 'workon-myproject'");
+      expect(commands).toContain("tmux -CC attach-session -t '=workon-myproject'");
     });
 
     it('should use -CC flag for iTerm when LC_TERMINAL is set', () => {
@@ -152,7 +152,7 @@ describe('TmuxManager', () => {
 
       const newTmux = new TmuxManager();
       const commands = newTmux.buildShellCommands('myproject', '/path/to/project');
-      expect(commands).toContain("tmux -CC attach-session -t 'workon-myproject'");
+      expect(commands).toContain("tmux -CC attach-session -t '=workon-myproject'");
     });
 
     it('should use -CC flag for iTerm when ITERM_SESSION_ID is set', () => {
@@ -161,7 +161,7 @@ describe('TmuxManager', () => {
 
       const newTmux = new TmuxManager();
       const commands = newTmux.buildShellCommands('myproject', '/path/to/project');
-      expect(commands).toContain("tmux -CC attach-session -t 'workon-myproject'");
+      expect(commands).toContain("tmux -CC attach-session -t '=workon-myproject'");
     });
 
     it('should not use -CC flag when TMUX_CC_NOT_SUPPORTED is set', () => {
@@ -171,8 +171,8 @@ describe('TmuxManager', () => {
 
       const newTmux = new TmuxManager();
       const commands = newTmux.buildShellCommands('myproject', '/path/to/project');
-      expect(commands).not.toContain("tmux -CC attach-session -t 'workon-myproject'");
-      expect(commands).toContain("tmux attach-session -t 'workon-myproject'");
+      expect(commands).not.toContain("tmux -CC attach-session -t '=workon-myproject'");
+      expect(commands).toContain("tmux attach-session -t '=workon-myproject'");
     });
   });
 });

--- a/tests/lib/worktree.test.ts
+++ b/tests/lib/worktree.test.ts
@@ -13,15 +13,12 @@ import { realpathSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
 import { simpleGit, type SimpleGit } from 'simple-git';
-import { createHash } from 'crypto';
-import { basename } from 'path';
 import {
   WorktreeManager,
   isPathInside,
   deriveProjectIdentifier,
-  getWorktreesDirForProject,
+  getWorktreesRoot,
   normalizePath,
-  resolveProjectIdentifier,
 } from '../../src/lib/worktree.js';
 
 /**
@@ -197,6 +194,31 @@ describe('WorktreeManager', () => {
       });
     });
 
+    it('is not confused by a branch that collides with the flattened name', async () => {
+      // 'feature/login' and 'feature-login' both map to directory 'feature-login',
+      // so the directory name alone cannot tell them apart. What `add` recorded can.
+      const wt = await manager.add({ branch: 'feature/login' });
+      await git.raw(['branch', 'feature-login']);
+      await simpleGit(wt.path).checkoutLocalBranch('branch-b');
+
+      expect(await manager.getOriginalBranch('feature-login')).toEqual({
+        branch: 'feature/login',
+        exists: true,
+      });
+    });
+
+    it('falls back to the directory name for worktrees created before recording', async () => {
+      const wt = await manager.add({ branch: 'legacy-wt' });
+      // Simulate a worktree created by an earlier version: no recorded branch
+      await git.raw(['config', '--local', '--unset', 'workon.worktree.legacy-wt.branch']);
+      await simpleGit(wt.path).checkoutLocalBranch('branch-b');
+
+      expect(await manager.getOriginalBranch('legacy-wt')).toEqual({
+        branch: 'legacy-wt',
+        exists: true,
+      });
+    });
+
     it('returns null for an unknown worktree', async () => {
       expect(await manager.getOriginalBranch('nope')).toBeNull();
     });
@@ -346,6 +368,27 @@ describe('WorktreeManager', () => {
     });
   });
 
+  describe('isManaged', () => {
+    it('recognises a worktree created under a different project identifier', async () => {
+      // The identifier hashes the project path, and that path reaches us either
+      // from git (a realpath) or from config (possibly via a symlink). Managed
+      // detection must not depend on which one produced the directory.
+      const wt = await manager.add({ branch: 'feat-a' });
+      const strayId = join(getWorktreesRoot(), 'someproject-deadbeef');
+      const moved = join(strayId, 'feat-a');
+      mkdirSync(strayId, { recursive: true });
+      await git.raw(['worktree', 'move', wt.path, moved]);
+
+      const info = await manager.get('feat-a');
+      expect(info).not.toBeNull();
+      expect(info!.path).toBe(moved);
+      expect(manager.isManaged(info!)).toBe(true);
+      expect((await manager.listManagedWorktrees()).map((w) => w.name)).toContain('feat-a');
+
+      rmSync(strayId, { recursive: true, force: true });
+    });
+  });
+
   describe('listManagedWorktrees', () => {
     it('excludes worktrees created outside the managed directory', async () => {
       const external = join(realpathSync(tmpdir()), `workon-external-${Date.now()}`);
@@ -448,34 +491,5 @@ describe('WorktreeManager', () => {
       const wt = await manager.add({ branch: 'feat-a' });
       await expect(manager.runPostSetupHook(wt.path)).rejects.toThrow(/hook not found/);
     });
-  });
-});
-
-describe('resolveProjectIdentifier', () => {
-  it('keeps using a pre-normalization worktrees directory when one exists', async () => {
-    // Path normalization changed the hash for anyone whose project path runs
-    // through a symlink; their existing worktrees must stay reachable.
-    const real = realpathSync(mkdtempSync(join(tmpdir(), 'workon-legacy-')));
-    const link = join(sandbox, 'legacy-link');
-    symlinkSync(real, link);
-
-    try {
-      const legacyId = `${basename(link)}-${createHash('sha256')
-        .update(link)
-        .digest('hex')
-        .substring(0, 8)}`;
-      const normalizedId = deriveProjectIdentifier(link);
-      expect(legacyId).not.toBe(normalizedId);
-
-      // No directory on disk yet: the normalized identifier is used
-      expect(resolveProjectIdentifier(link)).toBe(normalizedId);
-
-      // Once worktrees exist under the old identifier, keep using it
-      mkdirSync(getWorktreesDirForProject(legacyId), { recursive: true });
-      expect(resolveProjectIdentifier(link)).toBe(legacyId);
-    } finally {
-      unlinkSync(link);
-      rmSync(real, { recursive: true, force: true });
-    }
   });
 });

--- a/tests/lib/worktree.test.ts
+++ b/tests/lib/worktree.test.ts
@@ -1,0 +1,481 @@
+import { describe, it, expect, beforeEach, afterEach, beforeAll, afterAll } from 'vitest';
+import {
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+  mkdirSync,
+  chmodSync,
+  existsSync,
+  symlinkSync,
+  unlinkSync,
+} from 'fs';
+import { realpathSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { simpleGit, type SimpleGit } from 'simple-git';
+import { createHash } from 'crypto';
+import { basename } from 'path';
+import {
+  WorktreeManager,
+  isPathInside,
+  deriveProjectIdentifier,
+  getWorktreesDirForProject,
+  normalizePath,
+  resolveProjectIdentifier,
+} from '../../src/lib/worktree.js';
+
+/**
+ * These are integration tests against real git repositories: the bugs they
+ * cover (branch resolution, merge side effects, stale worktrees, hook
+ * execution) only show up when git is actually involved.
+ */
+
+const originalHome = process.env.HOME;
+let sandbox: string;
+
+/** Point HOME at a sandbox so managed worktrees never touch the real ~/.workon */
+beforeAll(() => {
+  sandbox = realpathSync(mkdtempSync(join(tmpdir(), 'workon-wt-')));
+  process.env.HOME = sandbox;
+});
+
+afterAll(() => {
+  process.env.HOME = originalHome;
+  rmSync(sandbox, { recursive: true, force: true });
+});
+
+async function makeRepo(name = 'proj'): Promise<{ dir: string; git: SimpleGit }> {
+  const dir = realpathSync(mkdtempSync(join(tmpdir(), `workon-${name}-`)));
+  const git = simpleGit(dir);
+  await git.init();
+  await git.addConfig('user.email', 'test@example.com');
+  await git.addConfig('user.name', 'Test');
+  await git.addConfig('commit.gpgsign', 'false');
+  writeFileSync(join(dir, 'README.md'), 'hello\n');
+  await git.add('.');
+  await git.commit('init');
+  await git.raw(['branch', '-M', 'main']);
+  return { dir, git };
+}
+
+async function commitFile(git: SimpleGit, dir: string, file: string, body: string) {
+  writeFileSync(join(dir, file), body);
+  await git.add(file);
+  await git.commit(`add ${file}`);
+}
+
+describe('isPathInside', () => {
+  it('accepts a real child', () => {
+    expect(isPathInside('/a/b/c', '/a/b')).toBe(true);
+  });
+
+  it('rejects a sibling that merely shares a prefix', () => {
+    // The bug: startsWith() treated app-1234 worktrees as living under app-12
+    expect(isPathInside('/root/app-1234abcd-old/feat', '/root/app-1234abcd')).toBe(false);
+  });
+
+  it('rejects the directory itself', () => {
+    expect(isPathInside('/a/b', '/a/b')).toBe(false);
+  });
+
+  it('rejects an unrelated path', () => {
+    expect(isPathInside('/x/y', '/a/b')).toBe(false);
+  });
+});
+
+describe('deriveProjectIdentifier', () => {
+  it('is stable for the same path', () => {
+    expect(deriveProjectIdentifier('/code/app')).toBe(deriveProjectIdentifier('/code/app'));
+  });
+
+  it('differs for same-named projects in different locations', () => {
+    expect(deriveProjectIdentifier('/code/a/app')).not.toBe(deriveProjectIdentifier('/code/b/app'));
+  });
+
+  it('resolves symlinked paths to the same identifier', () => {
+    const real = realpathSync(mkdtempSync(join(tmpdir(), 'workon-sym-')));
+    const link = join(sandbox, 'linked-project');
+    try {
+      symlinkSync(real, link);
+      expect(deriveProjectIdentifier(link)).toBe(deriveProjectIdentifier(real));
+    } finally {
+      unlinkSync(link);
+      rmSync(real, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('normalizePath', () => {
+  it('returns the input when the path does not exist', () => {
+    expect(normalizePath('/definitely/not/here')).toBe('/definitely/not/here');
+  });
+});
+
+describe('WorktreeManager', () => {
+  let dir: string;
+  let git: SimpleGit;
+  let manager: WorktreeManager;
+  const cleanup: string[] = [];
+
+  beforeEach(async () => {
+    ({ dir, git } = await makeRepo());
+    cleanup.push(dir);
+    manager = new WorktreeManager(dir);
+  });
+
+  afterEach(() => {
+    const worktreesDir = manager.getWorktreesDir();
+    rmSync(worktreesDir, { recursive: true, force: true });
+    while (cleanup.length) {
+      rmSync(cleanup.pop() as string, { recursive: true, force: true });
+    }
+  });
+
+  describe('getOriginalBranch', () => {
+    it('returns the branch the worktree was created for', async () => {
+      await manager.add({ branch: 'feature/login' });
+      expect(await manager.getOriginalBranch('feature-login')).toEqual({
+        branch: 'feature/login',
+        exists: true,
+      });
+    });
+
+    it('still returns it after the worktree checks out another branch', async () => {
+      // Regression: the old implementation read the *current* checkout from
+      // `git worktree list`, so `recycle` never switched back.
+      const wt = await manager.add({ branch: 'feature/login' });
+      await simpleGit(wt.path).checkoutLocalBranch('review-pr-42');
+
+      expect(await manager.getOriginalBranch('feature-login')).toEqual({
+        branch: 'feature/login',
+        exists: true,
+      });
+    });
+
+    it('reports the branch as missing once it has been deleted', async () => {
+      // The branch is typically cleaned up after it merges; the worktree still
+      // belongs to it, so callers can put it back rather than falling through
+      // to whatever branch the last task left checked out.
+      const wt = await manager.add({ branch: 'worktree-a' });
+      await simpleGit(wt.path).checkoutLocalBranch('branch-b');
+      await manager.getBranches();
+      await simpleGit(dir).raw(['branch', '-D', 'worktree-a']);
+
+      expect(await manager.getOriginalBranch('worktree-a')).toEqual({
+        branch: 'worktree-a',
+        exists: false,
+      });
+    });
+
+    it('falls back to the current branch for an external worktree', async () => {
+      const external = join(realpathSync(tmpdir()), `workon-ext-${Date.now()}`);
+      cleanup.push(external);
+      await git.raw(['worktree', 'add', '-b', 'ext-branch', external]);
+
+      expect(await manager.getOriginalBranch('ext-branch')).toEqual({
+        branch: 'ext-branch',
+        exists: true,
+      });
+    });
+
+    it('recovers a slash-bearing branch name from the remote once deleted', async () => {
+      // The directory name is a flattened form ('feature/login' -> 'feature-login'),
+      // so recreating from it alone would land on the wrong branch name.
+      const origin = join(realpathSync(tmpdir()), `workon-origin-${Date.now()}.git`);
+      cleanup.push(origin);
+      await git.raw(['init', '--bare', origin]);
+      await git.addRemote('origin', origin);
+
+      const wt = await manager.add({ branch: 'feature/login' });
+      await simpleGit(wt.path).push(['-u', 'origin', 'feature/login']);
+      await simpleGit(wt.path).checkoutLocalBranch('branch-b');
+      await git.raw(['branch', '-D', 'feature/login']);
+
+      expect(await manager.getOriginalBranch('feature-login')).toEqual({
+        branch: 'feature/login',
+        exists: false,
+      });
+    });
+
+    it('returns null for an unknown worktree', async () => {
+      expect(await manager.getOriginalBranch('nope')).toBeNull();
+    });
+  });
+
+  describe('add', () => {
+    it('creates a worktree under the managed directory', async () => {
+      const wt = await manager.add({ branch: 'feat-a' });
+      expect(isPathInside(wt.path, manager.getWorktreesDir())).toBe(true);
+      expect(manager.isManaged(wt)).toBe(true);
+      expect(existsSync(wt.path)).toBe(true);
+    });
+
+    it('refuses to add a duplicate without force', async () => {
+      await manager.add({ branch: 'feat-a' });
+      await expect(manager.add({ branch: 'feat-a' })).rejects.toThrow(/already exists/);
+    });
+
+    it('recovers when the worktree directory was deleted behind our back', async () => {
+      const wt = await manager.add({ branch: 'feat-a' });
+      rmSync(wt.path, { recursive: true, force: true });
+
+      // Previously this failed with "already exists" until the user pruned by hand
+      const recreated = await manager.add({ branch: 'feat-a' });
+      expect(existsSync(recreated.path)).toBe(true);
+    });
+
+    it('refuses to force-replace a worktree holding uncommitted changes', async () => {
+      const wt = await manager.add({ branch: 'feat-a' });
+      writeFileSync(join(wt.path, 'work-in-progress.txt'), 'do not lose me');
+
+      await expect(manager.add({ branch: 'feat-a', force: true })).rejects.toThrow(
+        /uncommitted changes/
+      );
+      expect(existsSync(join(wt.path, 'work-in-progress.txt'))).toBe(true);
+    });
+
+    it('force-replaces a clean worktree', async () => {
+      await manager.add({ branch: 'feat-a' });
+      const replaced = await manager.add({ branch: 'feat-a', force: true });
+      expect(existsSync(replaced.path)).toBe(true);
+    });
+  });
+
+  describe('merge', () => {
+    it('puts the main worktree back on the branch it started on', async () => {
+      await git.checkoutLocalBranch('scratch');
+      const wt = await manager.add({ branch: 'feat-a', baseBranch: 'main' });
+      await commitFile(simpleGit(wt.path), wt.path, 'feature.txt', 'work');
+
+      const result = await manager.merge('feat-a', { targetBranch: 'main' });
+
+      expect(result.previousBranch).toBe('scratch');
+      expect(result.restored).toBe(true);
+      expect(await manager.getCurrentBranch()).toBe('scratch');
+    });
+
+    it('actually merges the commits into the target branch', async () => {
+      const wt = await manager.add({ branch: 'feat-a', baseBranch: 'main' });
+      await commitFile(simpleGit(wt.path), wt.path, 'feature.txt', 'work');
+
+      await manager.merge('feat-a', { targetBranch: 'main' });
+
+      const log = await git.log(['main']);
+      expect(log.all.some((c) => c.message.includes('add feature.txt'))).toBe(true);
+    });
+
+    it('is not blocked by untracked files in the main worktree', async () => {
+      const wt = await manager.add({ branch: 'feat-a', baseBranch: 'main' });
+      await commitFile(simpleGit(wt.path), wt.path, 'feature.txt', 'work');
+      writeFileSync(join(dir, 'scratch-notes.txt'), 'untracked, harmless');
+
+      await expect(manager.merge('feat-a', { targetBranch: 'main' })).resolves.toBeTruthy();
+      expect(existsSync(join(dir, 'scratch-notes.txt'))).toBe(true);
+    });
+
+    it('refuses when the main worktree is dirty', async () => {
+      const wt = await manager.add({ branch: 'feat-a', baseBranch: 'main' });
+      await commitFile(simpleGit(wt.path), wt.path, 'feature.txt', 'work');
+      writeFileSync(join(dir, 'README.md'), 'edited but not committed\n');
+
+      await expect(manager.merge('feat-a', { targetBranch: 'main' })).rejects.toThrow(
+        /uncommitted changes/
+      );
+    });
+
+    it('refuses when the target branch is checked out in another worktree', async () => {
+      await manager.add({ branch: 'shared', baseBranch: 'main' });
+      const wt = await manager.add({ branch: 'feat-a', baseBranch: 'main' });
+      await commitFile(simpleGit(wt.path), wt.path, 'feature.txt', 'work');
+
+      await expect(manager.merge('feat-a', { targetBranch: 'shared' })).rejects.toThrow(
+        /checked out in worktree/
+      );
+    });
+
+    it('reports a no-op squash instead of failing on an empty commit', async () => {
+      await manager.add({ branch: 'feat-a', baseBranch: 'main' });
+
+      await expect(manager.merge('feat-a', { targetBranch: 'main', squash: true })).rejects.toThrow(
+        /already contained/
+      );
+      // Repo is left usable, on the branch it started on
+      expect(await manager.getCurrentBranch()).toBe('main');
+    });
+
+    it('leaves the repo on its original branch when the merge conflicts', async () => {
+      const wt = await manager.add({ branch: 'feat-a', baseBranch: 'main' });
+      await commitFile(simpleGit(wt.path), wt.path, 'README.md', 'from the worktree\n');
+      await commitFile(git, dir, 'README.md', 'from main\n');
+      await git.checkoutLocalBranch('scratch');
+
+      // Regression: simple-git reports a conflicted merge as a success because
+      // git writes CONFLICT to stdout, so this used to "succeed" and the caller
+      // went on to delete the worktree and its branch.
+      await expect(manager.merge('feat-a', { targetBranch: 'main' })).rejects.toThrow(/conflict/i);
+
+      expect(await manager.getCurrentBranch()).toBe('scratch');
+      const status = await git.status();
+      expect(status.conflicted).toHaveLength(0);
+    });
+  });
+
+  describe('remove', () => {
+    it('removes a managed worktree', async () => {
+      const wt = await manager.add({ branch: 'feat-a' });
+      await manager.remove('feat-a');
+      expect(existsSync(wt.path)).toBe(false);
+      expect(await manager.get('feat-a')).toBeNull();
+    });
+
+    it('refuses to remove a worktree with uncommitted changes', async () => {
+      const wt = await manager.add({ branch: 'feat-a' });
+      writeFileSync(join(wt.path, 'wip.txt'), 'unsaved');
+      await expect(manager.remove('feat-a')).rejects.toThrow(/uncommitted changes/);
+    });
+
+    it('cleans up a worktree whose directory is already gone', async () => {
+      const wt = await manager.add({ branch: 'feat-a' });
+      rmSync(wt.path, { recursive: true, force: true });
+      await manager.remove('feat-a');
+      expect(await manager.get('feat-a')).toBeNull();
+    });
+
+    it('refuses to remove the main worktree', async () => {
+      await expect(manager.remove('main')).rejects.toThrow(/main worktree/);
+    });
+  });
+
+  describe('listManagedWorktrees', () => {
+    it('excludes worktrees created outside the managed directory', async () => {
+      const external = join(realpathSync(tmpdir()), `workon-external-${Date.now()}`);
+      cleanup.push(external);
+      await git.raw(['worktree', 'add', '-b', 'external-branch', external]);
+      await manager.add({ branch: 'managed-branch' });
+
+      const managed = await manager.listManagedWorktrees();
+      expect(managed.map((w) => w.name)).toEqual(['managed-branch']);
+
+      const externalInfo = await manager.get('external-branch');
+      expect(externalInfo).not.toBeNull();
+      expect(manager.isManaged(externalInfo!)).toBe(false);
+    });
+  });
+
+  describe('hooks', () => {
+    function writeSetupHook(projectDir: string, body: string) {
+      mkdirSync(join(projectDir, '.workon'), { recursive: true });
+      const hookPath = join(projectDir, '.workon', 'worktree-setup.sh');
+      writeFileSync(hookPath, body);
+      chmodSync(hookPath, 0o755);
+      return hookPath;
+    }
+
+    it('runs a hook and returns its output', async () => {
+      writeSetupHook(dir, '#!/bin/sh\necho "setup for $WORKTREE_NAME"\n');
+      const wt = await manager.add({ branch: 'feat-a' });
+
+      const { stdout } = await manager.runPostSetupHook(wt.path);
+      expect(stdout.trim()).toBe('setup for feat-a');
+    });
+
+    it('exposes WORKTREE_PATH and PROJECT_PATH to the hook', async () => {
+      writeSetupHook(dir, '#!/bin/sh\necho "$PROJECT_PATH|$WORKTREE_PATH"\n');
+      const wt = await manager.add({ branch: 'feat-a' });
+
+      const { stdout } = await manager.runPostSetupHook(wt.path);
+      expect(stdout.trim()).toBe(`${dir}|${wt.path}`);
+    });
+
+    it('runs a hook from a project path containing spaces', async () => {
+      // Regression: exec() handed the path to /bin/sh, which word-split it
+      const spacedRoot = realpathSync(mkdtempSync(join(tmpdir(), 'workon-space-')));
+      const spaced = join(spacedRoot, 'my project');
+      mkdirSync(spaced);
+      cleanup.push(spacedRoot);
+
+      const spacedGit = simpleGit(spaced);
+      await spacedGit.init();
+      await spacedGit.addConfig('user.email', 'test@example.com');
+      await spacedGit.addConfig('user.name', 'Test');
+      writeFileSync(join(spaced, 'README.md'), 'hi\n');
+      await spacedGit.add('.');
+      await spacedGit.commit('init');
+      await spacedGit.raw(['branch', '-M', 'main']);
+
+      const spacedManager = new WorktreeManager(spaced);
+      writeSetupHook(spaced, '#!/bin/sh\necho ran-in-spaced-path\n');
+      const wt = await spacedManager.add({ branch: 'feat-a' });
+
+      try {
+        const { stdout } = await spacedManager.runPostSetupHook(wt.path);
+        expect(stdout.trim()).toBe('ran-in-spaced-path');
+      } finally {
+        rmSync(spacedManager.getWorktreesDir(), { recursive: true, force: true });
+      }
+    });
+
+    it("surfaces the hook's own error output when it fails", async () => {
+      writeSetupHook(dir, '#!/bin/sh\necho "dependency install failed" >&2\nexit 3\n');
+      const wt = await manager.add({ branch: 'feat-a' });
+
+      await expect(manager.runPostSetupHook(wt.path)).rejects.toThrow(/dependency install failed/);
+    });
+
+    it('survives a hook that produces more than 1MB of output', async () => {
+      // Regression: the default 1MB exec buffer killed chatty installers
+      writeSetupHook(
+        dir,
+        '#!/bin/sh\ni=0\nwhile [ $i -lt 40000 ]; do echo "line $i aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"; i=$((i+1)); done\n'
+      );
+      const wt = await manager.add({ branch: 'feat-a' });
+
+      const { stdout } = await manager.runPostSetupHook(wt.path);
+      expect(stdout.length).toBeGreaterThan(1024 * 1024);
+    });
+
+    it('runs a hook that has no shebang line', async () => {
+      // exec() handed these to /bin/sh, which interprets them; execFile cannot,
+      // so hooks that always worked must not break on upgrade.
+      writeSetupHook(dir, 'echo no-shebang-here\n');
+      const wt = await manager.add({ branch: 'feat-a' });
+
+      const { stdout } = await manager.runPostSetupHook(wt.path);
+      expect(stdout.trim()).toBe('no-shebang-here');
+    });
+
+    it('reports a missing hook clearly', async () => {
+      const wt = await manager.add({ branch: 'feat-a' });
+      await expect(manager.runPostSetupHook(wt.path)).rejects.toThrow(/hook not found/);
+    });
+  });
+});
+
+describe('resolveProjectIdentifier', () => {
+  it('keeps using a pre-normalization worktrees directory when one exists', async () => {
+    // Path normalization changed the hash for anyone whose project path runs
+    // through a symlink; their existing worktrees must stay reachable.
+    const real = realpathSync(mkdtempSync(join(tmpdir(), 'workon-legacy-')));
+    const link = join(sandbox, 'legacy-link');
+    symlinkSync(real, link);
+
+    try {
+      const legacyId = `${basename(link)}-${createHash('sha256')
+        .update(link)
+        .digest('hex')
+        .substring(0, 8)}`;
+      const normalizedId = deriveProjectIdentifier(link);
+      expect(legacyId).not.toBe(normalizedId);
+
+      // No directory on disk yet: the normalized identifier is used
+      expect(resolveProjectIdentifier(link)).toBe(normalizedId);
+
+      // Once worktrees exist under the old identifier, keep using it
+      mkdirSync(getWorktreesDirForProject(legacyId), { recursive: true });
+      expect(resolveProjectIdentifier(link)).toBe(legacyId);
+    } finally {
+      unlinkSync(link);
+      rmSync(real, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
An audit of the worktree subsystem, plugging bugs found by reading the code and reproducing each one against real git repositories and tmux 3.6a.

## The serious one: a conflicting merge destroyed the work

`simple-git` only treats a command as failed when it writes to **stderr**, and git announces merge conflicts on **stdout**. So `git.raw(['merge', branch])` came back looking successful. Reproduced against v3.8.0:

```
$ workon worktrees merge feat-x -y --delete-branch
✔ Worktree 'feat-x' removed
✔ Branch 'feat-x' deleted
Merge workflow completed successfully!
$ git status --short
UU README.md          # the merge never happened
```

The worktree was deleted, the branch force-deleted (`-D`), and the commits were left reachable only via reflog. The merge result is now inspected rather than trusted, and a failed merge is rolled back with nothing removed.

That same stderr-only error detection is a repo-wide footgun: `--quiet` git commands exit non-zero *silently*, so probing for a missing ref "succeeds" with an empty string. Ref probes now go through a `gitProbe()` helper that judges by output rather than by whether a throw happened.

## `worktree recycle` fast-forwarded the wrong branch

The reported symptom: create worktree `worktree-a`, agents check out `branch-b` inside it, and `recycle` fast-forwarded `branch-b` — so you had to `git switch worktree-a` first every time.

It read the branch from `git worktree list --porcelain`, which reports the *current* checkout. It now maps the managed directory name back to a branch, recovers the un-flattened name from the remote (`feature/login`, not `feature-login`), and recreates the branch with `--no-track` when it has been deleted. `--no-track` matters: a plain `-b` would set the new branch's upstream to `origin/main`, so a later `git push` from that worktree would target the default branch.

## tmux targeted the wrong session

`tmux -t name` falls back to **prefix** matching, so `workon-app_wt_feat` resolves to a live `workon-app_wt_feat2` when the former doesn't exist — `workon worktrees remove feat` could kill `feat2`'s session. All session and pane targets now use tmux's exact-match `=` prefix (`=name` for session targets, `=name:0.0` for pane targets — bare `=name` is not a valid pane target).

## Everything else

- **Session name mismatch** — `worktree merge` built it from the directory basename while `worktrees open` used the registered project name, so the session was never killed.
- **Hooks broke on any path with a space** — `exec()` handed the path to `/bin/sh`, which word-split it. Now `execFile`, with a timeout (`WORKON_HOOK_TIMEOUT`) and a 32MB buffer replacing Node's 1MB default, which silently killed chatty installers mid-run. Shebang-less hooks keep working via an explicit `/bin/sh` fallback.
- **`merge` parked your main checkout on the target branch** and never restored it, and didn't verify the main worktree was clean first (untracked files are still allowed).
- **Bare-repo worktrees** resolved to the repo's *parent* directory.
- **Symlinked project paths** produced two separate worktree directories for one project, because the interactive menu derives the path from config while the CLI derives it from git. Paths are realpath-normalized now, with a fallback so worktrees already created under the old identifier stay reachable.
- Path prefix matching misclassified a sibling project's worktrees as managed; `add --force` silently discarded uncommitted work; a manually deleted worktree directory needed a hand-run `git worktree prune`; `recycle` required network access and hardcoded `origin`; `hasUncommittedChanges` threw unhandled from inside a worktree.

## Behaviour changes worth knowing

Three things an existing user will notice at least once (all documented in the README):

1. **`worktrees open` attaches to a live session** instead of tearing it down — a running agent shouldn't die because you re-opened the worktree. `--recreate` restores the old behaviour.
2. **`merge` returns the main worktree to the branch it was on**, rather than leaving it on the target.
3. **`merge` refuses on a dirty main worktree**, and a conflicting merge is rolled back rather than left for you to resolve in place.

## Testing

467 tests pass (up from 414). The new tests are integration tests against real temp git repositories, not mocks — `$HOME` is sandboxed because managed worktrees live under `~/.workon/worktrees/`. The regression tests were each verified to **fail** against the pre-change code.

Reviewed by a code-review subagent, which caught a regression in the first round: the `--quiet` probe bug above, which made default-branch detection always return `main` and would have broken `recycle` for every `master`/`develop` repo. Fixed and covered by tests that fail on the buggy version.

## Known gap

If the worktree's branch exists but has **diverged** from the target (e.g. its commits landed via squash-merge), `recycle`'s `--ff-only` still fails and tells you to reset manually. Deliberate — it won't discard commits on its own. A `recycle --reset` flag is the natural follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)